### PR TITLE
MybatisConfig 추가

### DIFF
--- a/backend/src/main/java/com/ssg9th2team/geharbang/GeharbangApplication.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/GeharbangApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@MapperScan(basePackages = "com.ssg9th2team.geharbang.domain")
 public class GeharbangApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/accommodation/repository/mybatis/AccommodationMapper.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/accommodation/repository/mybatis/AccommodationMapper.java
@@ -3,5 +3,5 @@ package com.ssg9th2team.geharbang.domain.accommodation.repository.mybatis;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
-public interface AccommodationMapper {
+public interface AccommodationMapper  {
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/config/MyBatisConfig.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/config/MyBatisConfig.java
@@ -1,0 +1,11 @@
+package com.ssg9th2team.geharbang.global.config;
+
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@MapperScan(
+        basePackages = "com.ssg9th2team.geharbang.domain.**.repository.mybatis"
+)
+public class MyBatisConfig {
+}


### PR DESCRIPTION
💡 PR 제목

chore: [JHW] MyBatis / JPA 스캔 구조 정리 및 충돌 해결

🔗 관련 이슈

Refs: #
(설정 정리 작업이라 이슈 없으면 비워도 무방)

📌 작업 내용 요약

 MyBatis @MapperScan 범위를 repository.mybatis로 제한

 Application 클래스에서 중복 @MapperScan 제거

 JPA Repository와 MyBatis Mapper 패키지 분리

 MyBatis / JPA Bean 충돌 오류 해결

🧱 변경 범위 (Scope)
Backend

 설정(Config) 구조 변경

 MyBatis Mapper 스캔 범위 정리

 JPA Repository 충돌 이슈 해결

 API 추가/수정

 DB 스키마/쿼리

Frontend

 UI/라우팅

 상태관리/비동기 로직

 입력값/검증

🧪 테스트 내역
Backend

 로컬에서 애플리케이션 실행 확인
(DB 설정 전 단계까지 정상 기동 확인)

 단위 테스트

 API 수동 테스트

Frontend

 해당 없음

테스트 상세(필수)

MyBatis / JPA 설정 충돌 없이 ApplicationContext 정상 로딩 확인

ConflictingBeanDefinitionException 오류 재현되지 않음

🖼️ 화면 캡처 / 시연 영상

해당 없음 (설정 변경)

⚠️ 영향도 / 리스크 / 롤백

영향도

기존 API 로직 변경 없음

설정 및 패키지 스캔 범위만 조정

리스크

MyBatis Mapper가 repository.mybatis 패키지 외부에 있을 경우 스캔되지 않음
→ 팀 컨벤션 준수 필요

롤백 방법

해당 커밋 revert 시 이전 설정으로 복구 가능

✅ 리뷰어 체크 포인트

MyBatis @MapperScan 범위가 적절한지

JPA Repository 패키지 분리가 명확한지

팀 컨벤션 기준으로 확장 시 문제 없는 구조인지