### PR TITLE
  feat: [Auth] 회원가입 시 이름 입력 필드 추가 및 DB 저장

### DIFF
--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/SignupRequest.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/SignupRequest.java
@@ -15,6 +15,9 @@ import java.util.List;
 @AllArgsConstructor
 public class SignupRequest {
 
+    @NotBlank(message = "이름은 필수입니다.")
+    private String name;
+
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/UserResponse.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/UserResponse.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 public class UserResponse {
 
     private Long id;
+    private String name;
     private String email;
     private String phone;
     private UserRole role;
@@ -27,6 +28,7 @@ public class UserResponse {
     public static UserResponse from(User user) {
         return UserResponse.builder()
                 .id(user.getId())
+                .name(user.getName())
                 .email(user.getEmail())
                 .phone(user.getPhone())
                 .role(user.getRole())

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/User.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/User.java
@@ -26,6 +26,9 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
+    @Column(nullable = false, length = 50)
+    private String name;
+
     @Column(nullable = false, unique = true, length = 50)
     private String email;
 
@@ -62,7 +65,8 @@ public class User {
     private Set<Theme> themes = new HashSet<>();
 
     @Builder
-    public User(String email, String password, String phone, UserRole role, Boolean marketingAgreed, Boolean hostApproved, Set<Theme> themes) {
+    public User(String name, String email, String password, String phone, UserRole role, Boolean marketingAgreed, Boolean hostApproved, Set<Theme> themes) {
+        this.name = name;
         this.email = email;
         this.password = password;
         this.phone = phone;

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/service/AuthServiceImpl.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/service/AuthServiceImpl.java
@@ -66,6 +66,7 @@ public class AuthServiceImpl implements AuthService {
 
         // 4. User 엔티티 생성
         User user = User.builder()
+                .name(signupRequest.getName())
                 .email(signupRequest.getEmail())
                 .password(encodedPassword)
                 .phone(signupRequest.getPhone())

--- a/frontend/src/views/RegisterView/RegisterView.vue
+++ b/frontend/src/views/RegisterView/RegisterView.vue
@@ -123,6 +123,7 @@ const closeTermsModal = () => {
 }
 
 // Step 2: User Info
+const name = ref('')
 const email = ref('')
 const password = ref('')
 const passwordConfirm = ref('')
@@ -142,7 +143,7 @@ const allPasswordCriteriaMet = computed(() => passwordCriteria.value.every(c => 
 
 const passwordMatchState = computed(() => {
   if (!passwordConfirm.value) {
-    return null // Don't show any message if the confirm field is empty
+    return null
   }
   if (password.value === passwordConfirm.value) {
     return { valid: true, message: '비밀번호가 일치합니다.' }
@@ -203,14 +204,14 @@ const timer = ref(0)
 let timerId = null
 
 const isStep2Valid = computed(() => {
-  return isEmailChecked.value && 
+  return name.value &&
+         isEmailChecked.value &&
          isCodeVerified.value &&
          password.value &&
          password.value === passwordConfirm.value &&
          allPasswordCriteriaMet.value &&
          isPhoneValid.value
 })
-
 // Step 3: Theme Selection
 const themes = ref([
   { id: 1, label: '액티비티', selected: false },
@@ -398,6 +399,7 @@ const handleComplete = async () => {
 
     // 회원가입 데이터 생성
     const signupData = {
+      name: name.value,
       email: email.value,
       password: password.value,
       phone: phone.value,
@@ -446,6 +448,7 @@ const handleSkip = async () => {
     const marketingAgreed = marketingTerm ? marketingTerm.checked : false
 
     const signupData = {
+      name: name.value,
       email: email.value,
       password: password.value,
       phone: phone.value,
@@ -530,6 +533,11 @@ const handleSkip = async () => {
       <!-- Step 2: Info -->
       <template v-if="currentStep === 2">
         <div class="form-section">
+          <div class="input-group">
+            <label>이름 *</label>
+            <input type="text" v-model="name" placeholder="이름을 입력하세요" />
+          </div>
+
           <div class="input-group">
             <label>이메일 *</label>
             <div class="input-row">


### PR DESCRIPTION
💡 PR 제목
  feat: [Auth] 회원가입 시 이름 입력 필드 추가 및 DB 저장

  ---

  🔗 관련 이슈
  > 진행 중이면 Refs #123, 완전 해결이면 Closes #123 (완전히 끝났을 때만)
   - Closes: #(이슈 번호)

  ---

  📌 작업 내용 요약
   - [x] 회원가입 UI '정보입력' 단계에 '이름' 입력 필드를 추가했습니다.
   - [x] 백엔드 users 테이블에 name 컬럼을 추가하여 사용자 이름을 저장하도록 DB 스키마를 변경    
  
  ---

  🧱 변경 범위 (Scope)
  Backend
   - [x] API 추가/수정: signup API의 요청 DTO(SignupRequest)가 변경되었습니다.
   - [x] Validation/예외처리: SignupRequest에 name 필드가 비어있지 않도록 @NotBlank 검증을 추가했습니다.   
   - [ ] 인증/인가
   - [x] DB 스키마/쿼리: users 테이블에 name 컬럼이 추가되었고, 관련 INSERT 쿼리가 변경되었습니다.
   - [ ] 기타:

  Frontend
   - [x] UI/라우팅: 회원가입(RegisterView.vue) 페이지의 UI를 수정했습니다.
   - [ ] 상태관리/비동기 로직
         
   - [ ] 기타:

  ---

  🧪 테스트 내역
  Backend
   - [x] 로컬에서 애플리케이션 실행 확인
   - [ ] 단위 테스트 통과
   

  Frontend
   - [x] npm run dev 로컬 실행 확인
   - [x] 주요 화면/기능 수동 테스트

  테스트 상세(필수)
  > 테스트한 API/페이지/케이스를 간단히 적어주세요.
   - 회원가입 API (`POST /api/auth/signup`) 테스트:
     - 요청 본문에 name 필드를 포함하여 API 호출 시, DB의 users 테이블에 name 컬럼 값이 정상적으로
       저장되는지 확인.
     - name 필드를 누락하거나 빈 값으로 요청 시, 400 Bad Request 와 함께 유효성 검증 에러가 발생하는지     
       확인.
   - 회원가입 페이지 (`/register`) 테스트:
     - 이름 입력 필드가 이메일 필드 위에 정상적으로 표시되는지 확인.
     - 이름, 이메일, 비밀번호 등 2단계 폼의 모든 필수 값을 입력해야만 '다음' 버튼이 활성화되는지 확인.     

  ---

 
   - before:
     - 회원 정보 입력란에 '이메일' 필드부터 시작됨.
   - after:
     - '이름' 입력 필드가 '이메일' 필드 위에 추가됨.

  ---

  ⚠️ 영향도 / 리스크 / 롤백
  > 리뷰어가 “머지해도 되는지” 판단하기 위한 섹션입니다.
   - 영향도:
     - signup API의 요청 명세가 변경됩니다 (name 필드 추가).
     - users DB 테이블 스키마가 변경됩니다 (name 컬럼 추가).
   - 리스크: 배포 시 프론트엔드와 백엔드가 동시에 업데이트되지 않으면 회원가입 기능이 실패할 수 있습니다.  
     spring.jpa.hibernate.ddl-auto=update 설정이 켜져 있으면 앱 실행 시 users 테이블에 name 컬럼이 자동으로
     추가됩니다.
   - 롤백 방법: 이 PR에 해당하는 커밋을 revert 합니다. DB에 추가된 name 컬럼은 필요 시 수동으로 DROP 해야  
     합니다.

  ---

  ✅ 리뷰어 체크 포인트 (선택)

