### PR TITLE
feat : 회원가입 성별, 닉네임 추가 및 이메일 인증 검증 추가

### DIFF
--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/controller/AuthController.java
@@ -75,6 +75,14 @@ public class AuthController {
         return ResponseEntity.ok(isDuplicate);
     }
 
+    // 닉네임 중복 확인
+    @GetMapping("/check-nickname")
+    public ResponseEntity<Boolean> checkNicknameDuplicate(@RequestParam String nickname) {
+        log.info("닉네임 중복 확인 요청: {}", nickname);
+        boolean isDuplicate = authService.checkNicknameDuplicate(nickname);
+        return ResponseEntity.ok(isDuplicate);
+    }
+
 
     //이메일 인증 코드 전송
     @PostMapping("/send-verification")
@@ -90,6 +98,14 @@ public class AuthController {
     public ResponseEntity<Boolean> verifyCode(@Valid @RequestBody VerifyCodeRequest verifyCodeRequest) {
         log.info("이메일 인증 코드 확인 요청: {} / 코드: {}", verifyCodeRequest.getEmail(), verifyCodeRequest.getCode());
         boolean isVerified = authService.verifyEmailCode(verifyCodeRequest);
+        return ResponseEntity.ok(isVerified);
+    }
+
+    //이메일 인증 코드 확인만 (삭제하지 않음) - 비밀번호 찾기용
+    @PostMapping("/verify-code-only")
+    public ResponseEntity<Boolean> verifyCodeOnly(@Valid @RequestBody VerifyCodeRequest verifyCodeRequest) {
+        log.info("이메일 인증 코드 확인만 요청: {} / 코드: {}", verifyCodeRequest.getEmail(), verifyCodeRequest.getCode());
+        boolean isVerified = authService.verifyEmailCodeOnly(verifyCodeRequest);
         return ResponseEntity.ok(isVerified);
     }
 

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/SignupRequest.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/SignupRequest.java
@@ -1,8 +1,9 @@
 package com.ssg9th2team.geharbang.domain.auth.dto;
 
+import com.ssg9th2team.geharbang.domain.user.entity.Gender;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,8 +16,14 @@ import java.util.List;
 @AllArgsConstructor
 public class SignupRequest {
 
-    @NotBlank(message = "이름은 필수입니다.")
     private String name;
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 50, message = "닉네임은 2자 이상 50자 이하로 입력해주세요.")
+    private String nickname;
+
+    @NotNull(message = "성별은 필수입니다.")
+    private Gender gender;
 
     @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "올바른 이메일 형식이 아닙니다.")

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/UserResponse.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/UserResponse.java
@@ -2,6 +2,7 @@ package com.ssg9th2team.geharbang.domain.auth.dto;
 
 import com.ssg9th2team.geharbang.domain.auth.entity.User;
 import com.ssg9th2team.geharbang.domain.auth.entity.UserRole;
+import com.ssg9th2team.geharbang.domain.user.entity.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,8 +18,10 @@ public class UserResponse {
 
     private Long id;
     private String name;
+    private String nickname;
     private String email;
     private String phone;
+    private Gender gender;
     private UserRole role;
     private Boolean marketingAgreed;
     private Boolean hostApproved;
@@ -29,8 +32,10 @@ public class UserResponse {
         return UserResponse.builder()
                 .id(user.getId())
                 .name(user.getName())
+                .nickname(user.getNickname())
                 .email(user.getEmail())
                 .phone(user.getPhone())
+                .gender(user.getGender())
                 .role(user.getRole())
                 .marketingAgreed(user.getMarketingAgreed())
                 .hostApproved(user.getHostApproved())

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/User.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/User.java
@@ -1,6 +1,7 @@
 package com.ssg9th2team.geharbang.domain.auth.entity;
 
 import com.ssg9th2team.geharbang.domain.theme.entity.Theme;
+import com.ssg9th2team.geharbang.domain.user.entity.Gender;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,8 +27,14 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(length = 100) // nullable = true is default
     private String name;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String nickname;
+
+    @Column(nullable = false)
+    private Gender gender;
 
     @Column(nullable = false, unique = true, length = 50)
     private String email;
@@ -65,8 +72,10 @@ public class User {
     private Set<Theme> themes = new HashSet<>();
 
     @Builder
-    public User(String name, String email, String password, String phone, UserRole role, Boolean marketingAgreed, Boolean hostApproved, Set<Theme> themes) {
+    public User(String name, String nickname, Gender gender, String email, String password, String phone, UserRole role, Boolean marketingAgreed, Boolean hostApproved, Set<Theme> themes) {
         this.name = name;
+        this.nickname = nickname;
+        this.gender = gender;
         this.email = email;
         this.password = password;
         this.phone = phone;
@@ -82,7 +91,9 @@ public class User {
     }
 
     // 프로필 업데이트
-    public void updateProfile(String phone) {
+    public void updateProfile(String name, String nickname, String phone) {
+        this.name = name;
+        this.nickname = nickname;
         this.phone = phone;
     }
 

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/repository/UserRepository.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/repository/UserRepository.java
@@ -20,4 +20,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 이름과 전화번호로 사용자 조회
     Optional<User> findByNameAndPhone(String name, String phone);
+
+    // 닉네임 중복 체크
+    boolean existsByNickname(String nickname);
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/service/AuthService.java
@@ -30,11 +30,17 @@ public interface AuthService {
     // 이메일 중복 확인
     boolean checkEmailDuplicate(String email);
 
+    // 닉네임 중복 확인
+    boolean checkNicknameDuplicate(String nickname);
+
     // 이메일 인증 코드 전송
     void sendVerificationCode(String email);
 
     // 이메일 인증 코드 확인
     boolean verifyEmailCode(VerifyCodeRequest verifyCodeRequest);
+
+    // 이메일 인증 코드 확인만 (삭제하지 않음) - 비밀번호 찾기용
+    boolean verifyEmailCodeOnly(VerifyCodeRequest verifyCodeRequest);
 
     // 리프레시 토큰으로 액세스 토큰 재발급
     TokenResponse refresh(String refreshToken);

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/service/AuthServiceImpl.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/service/AuthServiceImpl.java
@@ -54,9 +54,12 @@ public class AuthServiceImpl implements AuthService {
     @Override
     @Transactional
     public UserResponse signup(SignupRequest signupRequest) {
-        // 1. 이메일 중복 체크
+        // 1. 이메일 및 닉네임 중복 체크
         if (userRepository.existsByEmail(signupRequest.getEmail())) {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+        if (userRepository.existsByNickname(signupRequest.getNickname())) {
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
         // 2. 비밀번호 암호화
@@ -72,6 +75,8 @@ public class AuthServiceImpl implements AuthService {
         // 4. User 엔티티 생성
         User user = User.builder()
                 .name(signupRequest.getName())
+                .nickname(signupRequest.getNickname())
+                .gender(signupRequest.getGender())
                 .email(signupRequest.getEmail())
                 .password(encodedPassword)
                 .phone(signupRequest.getPhone())
@@ -218,6 +223,12 @@ public class AuthServiceImpl implements AuthService {
         return userRepository.existsByEmail(email);
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public boolean checkNicknameDuplicate(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
 
     //이메일 인증 코드 전송
     @Override
@@ -243,6 +254,13 @@ public class AuthServiceImpl implements AuthService {
     @Transactional(readOnly = true)
     public boolean verifyEmailCode(VerifyCodeRequest verifyCodeRequest) {
         return verificationCodeService.verifyCode(verifyCodeRequest.getEmail(), verifyCodeRequest.getCode());
+    }
+
+    //이메일 인증 코드 확인만 (삭제하지 않음) - 비밀번호 찾기용
+    @Override
+    @Transactional(readOnly = true)
+    public boolean verifyEmailCodeOnly(VerifyCodeRequest verifyCodeRequest) {
+        return verificationCodeService.verifyCodeOnly(verifyCodeRequest.getEmail(), verifyCodeRequest.getCode());
     }
 
     @Override

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/converter/GenderConverter.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/converter/GenderConverter.java
@@ -1,0 +1,31 @@
+package com.ssg9th2team.geharbang.domain.user.converter;
+
+import com.ssg9th2team.geharbang.domain.user.entity.Gender;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.stream.Stream;
+
+@Converter(autoApply = true)
+public class GenderConverter implements AttributeConverter<Gender, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Gender gender) {
+        if (gender == null) {
+            return null;
+        }
+        return gender.getDescription();
+    }
+
+    @Override
+    public Gender convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+
+        return Stream.of(Gender.values())
+                .filter(g -> g.getDescription().equals(dbData))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/entity/Gender.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/entity/Gender.java
@@ -1,0 +1,13 @@
+package com.ssg9th2team.geharbang.domain.user.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+    MALE("남"),
+    FEMALE("여");
+
+    private final String description;
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/service/UserServiceImpl.java
@@ -25,7 +25,7 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        // Check for active reservations
+
         List<Reservation> reservations = reservationRepository.findByUserId(user.getId());
         boolean hasActiveReservations = reservations.stream()
                 .anyMatch(r -> r.getReservationStatus() != 3); // 3: Cancelled
@@ -34,7 +34,7 @@ public class UserServiceImpl implements UserService {
             throw new IllegalStateException("진행 중이거나 완료된 예약이 있어 탈퇴할 수 없습니다. 모든 예약을 취소한 후 다시 시도해주세요.");
         }
 
-        // Log the reasons for deletion
+
         log.info("사용자 {} 탈퇴. 사유: {}, 기타: {}", email, deleteAccountRequest.getReasons(),
                 deleteAccountRequest.getOtherReason());
 

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/util/VerificationCodeService.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/util/VerificationCodeService.java
@@ -40,6 +40,22 @@ public class VerificationCodeService {
         return false;
     }
 
+    // 비밀번호 찾기용: 검증만 하고 삭제하지 않음
+    public boolean verifyCodeOnly(String email, String code) {
+        String storedCode = emailCodeStorage.get(email);
+        Long expirationTime = codeExpiration.get(email);
+
+        if (storedCode == null || expirationTime == null) {
+            return false;
+        }
+
+        if (System.currentTimeMillis() > expirationTime) {
+            return false; // 만료되었지만 삭제하지 않음
+        }
+
+        return storedCode.equals(code); // 검증만 하고 삭제하지 않음
+    }
+
     public void removeCode(String email) {
         emailCodeStorage.remove(email);
         codeExpiration.remove(email);

--- a/frontend/src/api/authClient.js
+++ b/frontend/src/api/authClient.js
@@ -120,6 +120,14 @@ export async function checkEmailDuplicate(email) {
   })
 }
 
+// 닉네임 중복 확인
+export async function checkNicknameDuplicate(nickname) {
+  return apiRequest(`/api/auth/check-nickname?nickname=${encodeURIComponent(nickname)}`, {
+    method: 'GET',
+    skipAuth: true
+  });
+}
+
 // 이메일 인증 코드 전송
 export async function sendVerificationEmail(email) {
   return apiRequest('/api/auth/send-verification', {
@@ -132,6 +140,15 @@ export async function sendVerificationEmail(email) {
 // 이메일 인증 코드 확인
 export async function verifyEmailCode(email, code) {
   return apiRequest('/api/auth/verify-code', {
+    method: 'POST',
+    body: JSON.stringify({ email, code }),
+    skipAuth: true
+  })
+}
+
+// 이메일 인증 코드 확인만 (삭제하지 않음) - 비밀번호 찾기용
+export async function verifyEmailCodeOnly(email, code) {
+  return apiRequest('/api/auth/verify-code-only', {
     method: 'POST',
     body: JSON.stringify({ email, code }),
     skipAuth: true
@@ -221,8 +238,10 @@ export default {
   resetPassword,
   sendVerificationEmail,
   verifyEmailCode,
+  verifyEmailCodeOnly,
   logout,
   checkEmailDuplicate,
+  checkNicknameDuplicate,
   refreshAccessToken,
   authenticatedRequest,
   getAccessToken,

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -130,6 +130,11 @@ const router = createRouter({
             component: () => import('../views/LoginView/ResetPasswordView.vue')
         },
         {
+            path: '/reset-password-success',
+            name: 'reset-password-success',
+            component: () => import('../views/LoginView/ResetPasswordSuccessView.vue')
+        },
+        {
             path: '/host',
             name: 'host-dashboard',
             component: () => import('../views/HostView/HostDashboardView.vue'),

--- a/frontend/src/views/LoginView/FindEmailView.vue
+++ b/frontend/src/views/LoginView/FindEmailView.vue
@@ -65,7 +65,7 @@ const goToLogin = () => {
             <h1 class="page-title">이메일 찾기</h1>
 
             <div v-if="!foundEmail" class="form-section">
-                <p class="description">회원가입 시 입력했던 이름과 전화번호를 입력해주세요.</p>
+                <p class="description">회원가입 시 입력했던 <br/>이름과 전화번호를 입력해주세요.</p>
                 <div class="input-group">
                     <label for="name">이름</label>
                     <input type="text" id="name" v-model="name" placeholder="이름을 입력하세요" />

--- a/frontend/src/views/LoginView/FindPasswordView.vue
+++ b/frontend/src/views/LoginView/FindPasswordView.vue
@@ -1,42 +1,105 @@
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { useRouter } from 'vue-router';
-import { findPassword } from '@/api/authClient';
+import { findPassword, resetPassword, verifyEmailCodeOnly } from '@/api/authClient';
 
 const router = useRouter();
+
+// Step 1: Request Code Phase
 const email = ref('');
 const phone = ref('');
+const isCodeSent = ref(false); // Flag to show Step 2 UI
+const isVerified = ref(false); // Flag to show Step 3 UI
+
+// Step 2: Verify Code Phase
 const verificationCode = ref('');
+const timer = ref(0);
+let timerId = null;
+
+// Step 3: Reset Password Phase
+const newPassword = ref('');
+const newPasswordConfirm = ref('');
+const showPassword = ref(false);
+const showPasswordConfirm = ref(false);
+
+// Validation States
 const errorMessage = ref('');
-const successMessage = ref('');
 const isLoading = ref(false);
-const codeSent = ref(false);
 
-// 전화번호 자동 포맷팅
-watch(phone, (newValue) => {
-  let cleaned = newValue.replace(/\D/g, '');
-  let formatted = '';
+// Password criteria
+const passwordCriteria = ref([
+    { label: '영문', valid: false, regex: /[a-zA-Z]/ },
+    { label: '숫자', valid: false, regex: /[0-9]/ },
+    { label: '특수문자', valid: false, regex: /[!@#$%^&*(),.?":{}|<>]/ },
+    { label: '8자 이상 20자 이하', valid: false, regex: /^.{8,20}$/ }
+]);
+const allPasswordCriteriaMet = computed(() => passwordCriteria.value.every(c => c.valid));
 
-  if (cleaned.startsWith('010') && cleaned.length > 3) {
-    if (cleaned.length < 8) {
-      formatted = cleaned.substring(0, 3) + '-' + cleaned.substring(3);
-    } else {
-      formatted = cleaned.substring(0, 3) + '-' + cleaned.substring(3, 7) + '-' + cleaned.substring(7, 11);
+const passwordMatchState = computed(() => {
+    if (!newPasswordConfirm.value) {
+        return null;
     }
-  } else if (cleaned.length > 0) {
-    formatted = cleaned;
-  }
-
-  if (formatted !== newValue) {
-    phone.value = formatted;
-  }
+    if (newPassword.value === newPasswordConfirm.value) {
+        return { valid: true, message: '비밀번호가 일치합니다.' };
+    } else {
+        return { valid: false, message: '비밀번호가 일치하지 않습니다.' };
+    }
 });
 
-// 비밀번호 찾기 - 인증 코드 전송
+watch(newPassword, (newValue) => {
+    passwordCriteria.value.forEach(criterion => {
+        criterion.valid = criterion.regex.test(newValue);
+    });
+});
+
+// Phone number auto-formatting
+watch(phone, (newValue) => {
+    let cleaned = newValue.replace(/\D/g, '');
+    let formatted = '';
+
+    if (cleaned.startsWith('010') && cleaned.length > 3) {
+        if (cleaned.length < 8) {
+            formatted = cleaned.substring(0, 3) + '-' + cleaned.substring(3);
+        } else {
+            formatted = cleaned.substring(0, 3) + '-' + cleaned.substring(3, 7) + '-' + cleaned.substring(7, 11);
+        }
+    } else if (cleaned.length > 0) {
+        formatted = cleaned;
+    }
+    
+    if (formatted !== newValue) {
+        phone.value = formatted;
+    }
+});
+
+const formattedTimer = computed(() => {
+    const minutes = Math.floor(timer.value / 60);
+    const seconds = timer.value % 60;
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+});
+
+const startTimer = () => {
+    stopTimer();
+    timer.value = 180; // 3 minutes
+    timerId = setInterval(() => {
+        if (timer.value > 0) {
+            timer.value--;
+        } else {
+            stopTimer();
+            // Optionally, show a message that code expired
+        }
+    }, 1000);
+};
+
+const stopTimer = () => {
+    if (timerId) {
+        clearInterval(timerId);
+        timerId = null;
+    }
+};
+
 const handleSendCode = async () => {
     errorMessage.value = '';
-    successMessage.value = '';
-
     if (!email.value || !phone.value) {
         errorMessage.value = '이메일과 전화번호를 모두 입력해주세요.';
         return;
@@ -44,98 +107,232 @@ const handleSendCode = async () => {
 
     isLoading.value = true;
     try {
+        // findPassword API가 이미 사용자 확인 후 인증 코드를 전송함
         const response = await findPassword({ email: email.value, phone: phone.value });
         if (response.ok) {
-            codeSent.value = true;
-            successMessage.value = '인증 코드가 이메일로 전송되었습니다.';
+            isCodeSent.value = true;
+            startTimer();
+            openModal('인증번호가 발송되었습니다. 이메일을 확인해주세요.', 'success');
         } else {
-            errorMessage.value = response.data?.message || '일치하는 사용자 정보가 없습니다.';
+            errorMessage.value = response.data?.message || '사용자 정보를 찾을 수 없습니다.';
+            openModal(errorMessage.value, 'error');
         }
     } catch (error) {
-        console.error('비밀번호 찾기 오류:', error);
-        errorMessage.value = '비밀번호 찾기 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+        console.error('비밀번호 찾기 요청 오류:', error);
+        errorMessage.value = '비밀번호 찾기 요청 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+        openModal(errorMessage.value, 'error');
     } finally {
         isLoading.value = false;
     }
 };
 
-// 인증 코드 확인 (검증 없이 다음 페이지로 이동)
-const handleVerifyCode = () => {
-    errorMessage.value = '';
-    successMessage.value = '';
+const handleVerifyCode = async () => {
+    console.log('========= handleVerifyCode 호출됨 =========');
+    console.log('email:', email.value);
+    console.log('verificationCode:', verificationCode.value);
 
+    errorMessage.value = '';
     if (!verificationCode.value) {
-        errorMessage.value = '인증 코드를 입력해주세요.';
+        errorMessage.value = '인증번호를 입력해주세요.';
         return;
     }
 
     if (verificationCode.value.length !== 6) {
-        errorMessage.value = '인증 코드는 6자리입니다.';
+        errorMessage.value = '인증번호는 6자리입니다.';
         return;
     }
 
-    // 비밀번호 재설정 페이지로 이동 (실제 검증은 비밀번호 재설정 시 수행)
-    router.push({
-        name: 'reset-password',
-        query: { email: email.value, code: verificationCode.value }
-    });
+    console.log('API 호출 직전...');
+    isLoading.value = true;
+    try {
+        // 인증번호 검증 (삭제하지 않음)
+        console.log('verifyEmailCodeOnly 호출 시작');
+        const response = await verifyEmailCodeOnly(email.value, verificationCode.value);
+        console.log('========= API 응답 받음 =========');
+        console.log('인증번호 확인 응답:', response);
+        console.log('response.ok:', response.ok);
+        console.log('response.data:', response.data);
+        console.log('response.data === true:', response.data === true);
+
+        if (response.ok && response.data === true) {
+            console.log('인증 성공! isVerified를 true로 변경');
+            stopTimer();
+            isVerified.value = true;
+            openModal('인증이 완료되었습니다. 새 비밀번호를 설정해주세요.', 'success');
+        } else {
+            console.log('인증 실패 - response:', response);
+            errorMessage.value = '인증번호가 올바르지 않거나 만료되었습니다.';
+            openModal(errorMessage.value, 'error');
+        }
+    } catch (error) {
+        console.error('========= 인증번호 확인 오류 =========');
+        console.error('에러:', error);
+        errorMessage.value = '인증번호 확인 중 오류가 발생했습니다.';
+        openModal(errorMessage.value, 'error');
+    } finally {
+        isLoading.value = false;
+        console.log('========= handleVerifyCode 종료 =========');
+    }
 };
 
-const goToLogin = () => {
-    router.push('/login');
+const handleResetPassword = async () => {
+    errorMessage.value = '';
+    if (!newPassword.value || !newPasswordConfirm.value) {
+        errorMessage.value = '새 비밀번호를 모두 입력해주세요.';
+        return;
+    }
+    if (newPassword.value !== newPasswordConfirm.value) {
+        errorMessage.value = '새 비밀번호가 일치하지 않습니다.';
+        return;
+    }
+    if (!allPasswordCriteriaMet.value) {
+        errorMessage.value = '비밀번호 정책을 확인해주세요.';
+        return;
+    }
+
+    isLoading.value = true;
+    try {
+        const response = await resetPassword({
+            email: email.value,
+            code: verificationCode.value,
+            newPassword: newPassword.value
+        });
+        if (response.ok) {
+            openModal('비밀번호가 성공적으로 변경되었습니다.', 'success', () => {
+                router.push('/login');
+            });
+        } else {
+            errorMessage.value = response.data?.message || '비밀번호 변경에 실패했습니다.';
+            openModal(errorMessage.value, 'error');
+        }
+    } catch (error) {
+        console.error('비밀번호 재설정 오류:', error);
+        errorMessage.value = '비밀번호 재설정 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+        openModal(errorMessage.value, 'error');
+    } finally {
+        isLoading.value = false;
+    }
+};
+
+// Modal Logic (reused from RegisterView)
+const showModal = ref(false);
+const modalMessage = ref('');
+const modalType = ref('info');
+const modalCallback = ref(null);
+
+const openModal = (message, type = 'info', callback = null) => {
+    modalMessage.value = message;
+    modalType.value = type;
+    modalCallback.value = callback;
+    showModal.value = true;
+};
+
+const closeModal = () => {
+    showModal.value = false;
+    if (modalCallback.value) {
+        modalCallback.value();
+        modalCallback.value = null;
+    }
+};
+
+const goBack = () => {
+    router.back();
 };
 </script>
 
 <template>
     <div class="find-password-page">
         <div class="find-password-container">
-            <h1 class="page-title">비밀번호 찾기</h1>
+            <div class="page-header">
+                <button class="back-btn" @click="goBack">←</button>
+                <h1 class="page-title">비밀번호 찾기</h1>
+            </div>
 
-            <div class="form-section">
-                <p class="description">
-                    {{ codeSent ? '이메일로 전송된 인증 코드를 입력해주세요.' : '회원가입 시 입력했던 이메일과 전화번호를 입력해주세요.' }}
-                </p>
+            <!-- Phase 1: Request Code -->
+            <div v-if="!isCodeSent" class="form-section">
+                <p class="description">회원가입 시 입력했던<br/>이메일과 전화번호를 입력해주세요.</p>
+                <div class="input-group">
+                    <label for="email">이메일</label>
+                    <input type="email" id="email" v-model="email" placeholder="example@email.com" />
+                </div>
+                <div class="input-group">
+                    <label for="phone">전화번호</label>
+                    <input type="tel" id="phone" v-model="phone" placeholder="010-1234-5678" />
+                </div>
+                <button class="submit-btn" @click="handleSendCode" :disabled="isLoading">
+                    {{ isLoading ? '전송 중...' : '인증 코드 전송' }}
+                </button>
+            </div>
 
-                <div v-if="!codeSent">
-                    <div class="input-group">
-                        <label for="email">이메일</label>
-                        <input type="email" id="email" v-model="email" placeholder="example@email.com" />
+            <!-- Phase 2: Verify Code -->
+            <div v-else-if="isCodeSent && !isVerified" class="form-section">
+                <p class="description">이메일로 전송된 인증번호를 입력해주세요.</p>
+                <div class="input-group">
+                    <label for="verificationCode">인증번호</label>
+                    <div class="input-row">
+                        <input type="text" id="verificationCode" v-model="verificationCode" placeholder="인증번호 6자리" maxlength="6" />
+                        <span v-if="timer > 0" class="timer">{{ formattedTimer }}</span>
                     </div>
-                    <div class="input-group">
-                        <label for="phone">전화번호</label>
-                        <input type="tel" id="phone" v-model="phone" placeholder="010-1234-5678" />
-                    </div>
+                </div>
+                <button class="submit-btn" @click="handleVerifyCode" :disabled="isLoading || !verificationCode">
+                    {{ isLoading ? '확인 중...' : '인증 확인' }}
+                </button>
+                <button class="resend-btn" @click="handleSendCode" :disabled="isLoading">
+                    인증 코드 재전송
+                </button>
+            </div>
 
-                    <button class="submit-btn" @click="handleSendCode" :disabled="isLoading">
-                        {{ isLoading ? '전송 중...' : '인증 코드 전송' }}
-                    </button>
+            <!-- Phase 3: Reset Password -->
+            <div v-else-if="isVerified" class="form-section">
+                <p class="description">새로운 비밀번호를 설정해주세요.</p>
+                <div class="input-group">
+                    <label for="newPassword">새 비밀번호</label>
+                    <div class="input-wrapper">
+                        <input :type="showPassword ? 'text' : 'password'" id="newPassword" v-model="newPassword" placeholder="새 비밀번호를 입력하세요" />
+                        <button type="button" class="toggle-btn" @click="showPassword = !showPassword">
+                            <svg v-if="showPassword" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+                            <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-10-7-10-7a13.16 13.16 0 0 1 1.67-2.68L4 11"/><path d="M12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68M17.94 17.94 4 4"/></svg>
+                        </button>
+                    </div>
+                    <div class="password-criteria">
+                        <span v-for="criterion in passwordCriteria" :key="criterion.label" :class="{ 'is-valid': criterion.valid }">
+                            <svg v-if="criterion.valid" class="check-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                            <span class="criteria-label">{{ criterion.label }}</span>
+                        </span>
+                    </div>
                 </div>
 
-                <div v-else>
-                    <div class="input-group">
-                        <label for="code">인증 코드</label>
-                        <input
-                            type="text"
-                            id="code"
-                            v-model="verificationCode"
-                            placeholder="6자리 인증 코드"
-                            maxlength="6"
-                        />
+                <div class="input-group">
+                    <label for="newPasswordConfirm">새 비밀번호 확인</label>
+                    <div class="input-wrapper">
+                        <input :type="showPasswordConfirm ? 'text' : 'password'" id="newPasswordConfirm" v-model="newPasswordConfirm" placeholder="새 비밀번호를 다시 입력하세요" />
+                        <button type="button" class="toggle-btn" @click="showPasswordConfirm = !showPasswordConfirm">
+                            <svg v-if="showPasswordConfirm" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+                            <svg v-else xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-10-7-10-7a13.16 13.16 0 0 1 1.67-2.68L4 11"/><path d="M12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68M17.94 17.94 4 4"/></svg>
+                        </button>
                     </div>
-
-                    <button class="submit-btn" @click="handleVerifyCode">
-                        다음 단계로
-                    </button>
-
-                    <button class="resend-btn" @click="handleSendCode" :disabled="isLoading">
-                        인증 코드 재전송
-                    </button>
+                    <span v-if="passwordMatchState" class="email-check-message" :class="{ 'success-match': passwordMatchState.valid, 'error': !passwordMatchState.valid }">
+                        {{ passwordMatchState.message }}
+                    </span>
                 </div>
+                <button class="submit-btn" @click="handleResetPassword" :disabled="isLoading || !allPasswordCriteriaMet || (passwordMatchState && !passwordMatchState.valid)">
+                    {{ isLoading ? '변경 중...' : '비밀번호 변경' }}
+                </button>
+            </div>
 
-                <p v-if="successMessage" class="success-message">{{ successMessage }}</p>
-                <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+            <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+        </div>
 
-                <button class="back-btn" @click="goToLogin">로그인 페이지로 돌아가기</button>
+        <!-- Modal -->
+        <div v-if="showModal" class="modal-overlay" @click.self="closeModal">
+            <div class="modal-content">
+                <div class="modal-icon" :class="modalType">
+                    <span v-if="modalType === 'success'">✓</span>
+                    <span v-else-if="modalType === 'error'">!</span>
+                    <span v-else>i</span>
+                </div>
+                <p class="modal-message">{{ modalMessage }}</p>
+                <button class="modal-btn" @click="closeModal">확인</button>
             </div>
         </div>
     </div>
@@ -161,11 +358,29 @@ const goToLogin = () => {
     text-align: center;
 }
 
+.page-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 2rem;
+}
+
+.back-btn {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+    padding: 0;
+    margin-right: 1rem;
+    color: #333;
+}
+
 .page-title {
     font-size: 1.8rem;
     font-weight: 700;
     color: #333;
-    margin-bottom: 1.5rem;
+    flex-grow: 1; /* Center title */
+    text-align: center;
+    margin: 0;
 }
 
 .description {
@@ -178,7 +393,7 @@ const goToLogin = () => {
 .form-section {
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: 1.5rem; /* Good spacing between input groups */
 }
 
 .input-group {
@@ -193,13 +408,26 @@ const goToLogin = () => {
     margin-bottom: 0.5rem;
 }
 
-.input-group input {
+.input-row {
+    display: flex;
+    gap: 0.5rem; /* Spacing for input and button */
+    align-items: center;
+}
+
+.input-group input[type="email"],
+.input-group input[type="tel"],
+.input-group input[type="text"] {
     width: 100%;
     padding: 0.8rem;
     border: 1px solid #ddd;
     border-radius: 8px;
     font-size: 1rem;
     outline: none;
+}
+
+.input-row input[type="text"] {
+    flex: 1;
+    width: auto;
 }
 
 .input-group input:focus {
@@ -217,6 +445,7 @@ const goToLogin = () => {
     font-weight: 700;
     cursor: pointer;
     transition: background 0.3s ease;
+    margin-top: 1rem;
 }
 
 .submit-btn:hover {
@@ -254,31 +483,153 @@ const goToLogin = () => {
     cursor: not-allowed;
 }
 
-.back-btn {
-    width: 100%;
-    padding: 0.8rem;
-    background: transparent;
-    color: #666;
-    border: none;
-    border-radius: 8px;
+.timer {
     font-size: 0.95rem;
-    cursor: pointer;
-    transition: color 0.3s ease;
-}
-
-.back-btn:hover {
-    color: #333;
-    text-decoration: underline;
-}
-
-.success-message {
-    color: var(--primary);
-    font-size: 0.9rem;
-    font-weight: 600;
+    color: #ef4444; /* Red color for timer */
+    white-space: nowrap;
+    padding: 0 0.5rem;
 }
 
 .error-message {
     color: #dc2626;
     font-size: 0.9rem;
+    margin-top: 1rem;
+    text-align: center;
+}
+
+/* Password input specific styles */
+.input-wrapper {
+    display: flex;
+    align-items: center;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.input-wrapper input {
+    border: none;
+    border-radius: 0;
+    padding: 0.8rem;
+    flex: 1;
+    width: 100%;
+}
+
+.toggle-btn {
+    background: none;
+    border: none;
+    padding: 0 0.8rem; /* Adjust padding */
+    cursor: pointer;
+    color: #9ca3af;
+    display: flex; /* For SVG centering */
+    align-items: center;
+}
+
+.toggle-btn:hover {
+    color: #374151;
+}
+
+.password-criteria {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #a1a1aa;
+    margin-top: 0.5rem;
+}
+
+.password-criteria > span {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    white-space: nowrap;
+}
+
+.password-criteria .is-valid {
+    color: var(--primary); /* Dark green for valid */
+}
+
+.check-icon {
+    width: 14px; /* Smaller check icon */
+    height: 14px;
+    stroke-width: 2.5;
+}
+
+.email-check-message { /* Reusing class for password match state */
+    font-size: 0.85rem;
+    margin-top: 0.5rem;
+    display: block;
+}
+
+.email-check-message.success-match {
+    color: var(--primary);
+}
+
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: white;
+    border-radius: 16px;
+    padding: 2rem;
+    max-width: 320px;
+    width: 90%;
+    text-align: center;
+}
+
+.modal-icon {
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 1rem;
+    font-size: 1.5rem;
+    font-weight: bold;
+}
+
+.modal-icon.success {
+    background: var(--primary);
+    color: #004d40;
+}
+
+.modal-icon.error {
+    background: #fee2e2;
+    color: #dc2626;
+}
+
+.modal-icon.info {
+    background: #e0f2fe;
+    color: #0284c7;
+}
+
+.modal-message {
+    font-size: 1rem;
+    color: #333;
+    margin-bottom: 1.5rem;
+    line-height: 1.5;
+}
+
+.modal-btn {
+    width: 100%;
+    padding: 0.8rem;
+    background: var(--primary);
+    color: #004d40;
+    border: none;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
 }
 </style>

--- a/frontend/src/views/LoginView/ResetPasswordSuccessView.vue
+++ b/frontend/src/views/LoginView/ResetPasswordSuccessView.vue
@@ -1,0 +1,93 @@
+<template>
+    <div class="reset-success-page">
+        <div class="reset-success-container">
+            <div class="icon-wrapper success">
+                <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M22 11.08V12a10 10 0 1 1-5.93-8.1"></path>
+                    <path d="M22 4L12 14.01l-3-3"></path>
+                </svg>
+            </div>
+            <h1 class="page-title">비밀번호 변경 완료</h1>
+            <p class="description">성공적으로 비밀번호가 변경되었습니다.</p>
+            <p class="description">새로운 비밀번호로 로그인해주세요.</p>
+            <button class="go-to-login-btn" @click="goToLogin">로그인 페이지로 이동</button>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
+
+const goToLogin = () => {
+    router.push('/login');
+};
+</script>
+
+<style scoped>
+.reset-success-page {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background: #f9fafb;
+    padding: 1rem;
+}
+
+.reset-success-container {
+    background: white;
+    max-width: 400px;
+    width: 100%;
+    border-radius: 16px;
+    padding: 2.5rem;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
+    text-align: center;
+}
+
+.icon-wrapper {
+    margin: 0 auto 1.5rem;
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.icon-wrapper.success {
+    background-color: var(--primary); /* Light green/teal */
+    color: white;
+}
+
+.page-title {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: #333;
+    margin-bottom: 1rem;
+}
+
+.description {
+    font-size: 0.95rem;
+    color: #666;
+    margin-bottom: 0.5rem;
+}
+
+.go-to-login-btn {
+    width: 100%;
+    padding: 1rem;
+    background: #333;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 1.1rem;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.3s ease;
+    margin-top: 2rem;
+}
+
+.go-to-login-btn:hover {
+    background: #555;
+}
+</style>


### PR DESCRIPTION
● 💡 PR 제목

  feat: [LJH] 회원가입 필드 추가 및 이메일/비밀번호 찾기 기능 구현

  ---
  🔗 관련 이슈

  - Refs: #116 

  ---
  📌 작업 내용 요약

  - 회원가입 시 닉네임, 성별 필드 추가
  - 닉네임 중복 확인 API 구현
  - 이메일 찾기 기능 구현 (이름 + 전화번호로 조회)
  - 비밀번호 찾기 기능 구현 (이메일 + 전화번호 인증 → 비밀번호 재설정)
  - 인증 코드 검증 로직 개선 (검증 전용 API 추가)

  ---
  🧱 변경 범위 (Scope)

  Backend

  - API 추가/수정
    - POST /api/auth/find-email - 이메일 찾기
    - POST /api/auth/find-password - 비밀번호 찾기 (인증 코드 전송)
    - POST /api/auth/reset-password - 비밀번호 재설정
    - GET /api/auth/check-nickname - 닉네임 중복 확인
    - POST /api/auth/verify-code-only - 인증 코드 검증만 (삭제 안 함)
    - 
  - Validation/예외처리
    - 닉네임, 성별 필수 검증
    - 이메일/비밀번호 찾기 시 사용자 정보 일치 여부 검증
  - DB 스키마/쿼리
    - User 테이블에 nickname, gender 컬럼 추가
    - findByNameAndPhone 쿼리 메서드 추가
    - existsByNickname 쿼리 메서드 추가
  - 기타:
    - VerificationCodeService에 검증 전용 메서드 추가
    - 비밀번호 재설정 로직 (인증 코드 검증 + 비밀번호 암호화)

  Frontend

  - UI/라우팅
    - 회원가입 페이지에 닉네임, 성별 입력 필드 추가
    - 이메일 찾기 페이지 (/find-email)
    - 비밀번호 찾기 페이지 (/find-password) - 3단계 플로우
  - 상태관리/비동기 로직
    - 닉네임 중복 확인 로직
    - 이메일/비밀번호 찾기 API 연동
    - 인증 코드 타이머 (3분) 및 재전송 기능
  - 입력값/검증
    - 닉네임 중복 확인
    - 전화번호 자동 포맷팅 (010-1234-5678)
    - 인증 코드 6자리 검증
    - 비밀번호 정책 검증 (영문/숫자/특수문자, 8-20자)

  ---
  🧪 테스트 내역

  Backend

  - 로컬에서 애플리케이션 실행 확인
  - 단위 테스트 통과
  - API 수동 테스트 (Postman)

  Frontend

  - npm run dev 로컬 실행 확인
  - 주요 화면/기능 수동 테스트

  테스트 상세(필수)

  회원가입
  - 닉네임 중복 확인 (중복 시 에러 메시지 표시)
  - 성별 선택 (남/여)
  - 모든 필드 입력 후 회원가입 성공

  이메일 찾기
  - 이름 + 전화번호 입력 → 이메일 조회 성공
  - 일치하지 않는 정보 입력 → 에러 메시지 표시

  비밀번호 찾기
  - 1단계: 이메일 + 전화번호 입력 → 인증 코드 전송
  - 2단계: 인증 코드 입력 및 검증 (맞으면 다음 단계, 틀리면 에러)
  - 3단계: 새 비밀번호 입력 및 재설정 → 로그인 페이지 이동

  ---
  🖼️ 화면 캡처 / 시연 영상 (Frontend 변경 시 권장)

  before:
  - 회원가입: 이름, 이메일, 비밀번호, 전화번호만 입력
  - 비밀번호 찾기 : 2단계 (인증 코드 전송 -> 비밀번호 재설정 

  after:
  - 회원가입: 닉네임(중복 확인), 성별 선택 추가
  - 이메일 찾기: 이름 + 전화번호로 이메일 조회
  - 비밀번호 찾기: 3단계 플로우 (인증 코드 전송 → 검증 → 비밀번호 재설정)

  ---
  ⚠️ 영향도 / 리스크 / 롤백

  영향도:
  - DB 스키마 변경: User 테이블에 nickname, gender 컬럼 추가 (기존 데이터 영향 없음, NULL 허용)
  - 회원가입 API 변경: 요청 필드 추가 (nickname, gender 필수)
  - 기존 회원가입 클라이언트는 수정 필요

  리스크:
  - DB 마이그레이션 필요 (nickname, gender 컬럼 추가)
  - 기존 사용자 데이터에 nickname, gender 값이 NULL일 수 있음
  - 인증 코드 검증 로직 변경으로 인한 기존 이메일 인증 기능 영향 가능성 (분리하여 위험 최소화)

  롤백 방법:
  - Git revert 커밤으로 코드 롤백 가능
  - DB 마이그레이션 롤백 시 ALTER TABLE users DROP COLUMN nickname, gender 필요
  - VerificationCodeService의 기존 verifyCode 메서드는 그대로 유지되어 회원가입 인증은 영향 없음

  ---
  ✅ 리뷰어 체크 포인트 (선택)

  중점 리뷰 요청 사항:
  1. 인증 코드 검증 로직: verifyCodeOnly() 메서드가 검증만 하고 삭제하지 않는지 확인
  2. 비밀번호 재설정 플로우: 인증 코드를 2번 검증하는 로직의 안전성 (2단계에서 검증, 3단계에서 검증 후 삭제)
  3. 닉네임 중복 확인: 동시성 문제 (중복 확인 후 회원가입 사이에 다른 사용자가 같은 닉네임 사용 가능성)
  4. DB 스키마: nickname 컬럼에 UNIQUE 제약조건 필요 여부
  5. 예외 처리: 이메일/비밀번호 찾기 시 사용자 정보 불일치 시 적절한 에러 메시지 반환 여부
