### PR TITLE
feat : 네이버 로그인 구현 기능및 회원 정보 수정 기능 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	// Mail
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	// OAuth2 Client
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	// Google Cloud Vision OCR
 	implementation platform('com.google.cloud:libraries-bom:26.32.0')
 	implementation 'com.google.cloud:google-cloud-vision'

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/SocialProvider.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/SocialProvider.java
@@ -1,0 +1,8 @@
+package com.ssg9th2team.geharbang.domain.auth.entity;
+
+public enum SocialProvider {
+    NAVER,
+    KAKAO,
+    GOOGLE,
+    LOCAL  // 일반 로그인 (이메일/비밀번호)
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/User.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/User.java
@@ -33,7 +33,7 @@ public class User {
     @Column(nullable = false, unique = true, length = 50)
     private String nickname;
 
-    @Column(nullable = false)
+    @Column // nullable = true (소셜 로그인 시 NULL 가능)
     private Gender gender;
 
     @Column(nullable = false, unique = true, length = 50)
@@ -42,8 +42,15 @@ public class User {
     @Column(length = 255) // BCrypt 암호화를 위해 255로 설정
     private String password; // 소셜 로그인 시 NULL 가능
 
-    @Column(nullable = false, length = 50)
+    @Column(length = 50) // 소셜 로그인 시 NULL 가능
     private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_provider", length = 20)
+    private SocialProvider socialProvider; // 소셜 로그인 제공자 (NAVER, KAKAO, GOOGLE, LOCAL)
+
+    @Column(name = "social_id", length = 100)
+    private String socialId; // 소셜 로그인 ID
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
@@ -72,7 +79,7 @@ public class User {
     private Set<Theme> themes = new HashSet<>();
 
     @Builder
-    public User(String name, String nickname, Gender gender, String email, String password, String phone, UserRole role, Boolean marketingAgreed, Boolean hostApproved, Set<Theme> themes) {
+    public User(String name, String nickname, Gender gender, String email, String password, String phone, UserRole role, Boolean marketingAgreed, Boolean hostApproved, Set<Theme> themes, SocialProvider socialProvider, String socialId) {
         this.name = name;
         this.nickname = nickname;
         this.gender = gender;
@@ -83,6 +90,8 @@ public class User {
         this.marketingAgreed = marketingAgreed != null ? marketingAgreed : false;
         this.hostApproved = hostApproved;
         this.themes = themes;
+        this.socialProvider = socialProvider;
+        this.socialId = socialId;
     }
 
     // 비밀번호 업데이트
@@ -93,6 +102,12 @@ public class User {
     // 프로필 업데이트
     public void updateProfile(String name, String nickname, String phone) {
         this.name = name;
+        this.nickname = nickname;
+        this.phone = phone;
+    }
+
+    // 닉네임, 전화번호만 업데이트
+    public void updateProfile(String nickname, String phone) {
         this.nickname = nickname;
         this.phone = phone;
     }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/UserSocial.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/UserSocial.java
@@ -1,0 +1,59 @@
+package com.ssg9th2team.geharbang.domain.auth.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_social")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class UserSocial {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "social_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SocialProvider provider; // GOOGLE, KAKAO, NAVER
+
+    @Column(name = "provider_uid", nullable = false, length = 255)
+    private String providerUid; // 소셜 로그인 제공자의 고유 ID
+
+    @Column(length = 255)
+    private String email; // 소셜 계정 이메일
+
+    @Column(name = "profile_image", length = 255)
+    private String profileImage; // 프로필 이미지 URL
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public UserSocial(User user, SocialProvider provider, String providerUid, String email, String profileImage) {
+        this.user = user;
+        this.provider = provider;
+        this.providerUid = providerUid;
+        this.email = email;
+        this.profileImage = profileImage;
+    }
+
+    // 프로필 이미지 업데이트
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/repository/UserRepository.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.ssg9th2team.geharbang.domain.auth.repository;
 
+import com.ssg9th2team.geharbang.domain.auth.entity.SocialProvider;
 import com.ssg9th2team.geharbang.domain.auth.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -23,4 +24,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 닉네임 중복 체크
     boolean existsByNickname(String nickname);
+
+    // 특정 사용자를 제외하고 닉네임 중복 체크
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
+
+    // 소셜 로그인 사용자 조회
+    Optional<User> findBySocialProviderAndSocialId(SocialProvider socialProvider, String socialId);
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/repository/UserSocialRepository.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/repository/UserSocialRepository.java
@@ -1,0 +1,23 @@
+package com.ssg9th2team.geharbang.domain.auth.repository;
+
+import com.ssg9th2team.geharbang.domain.auth.entity.SocialProvider;
+import com.ssg9th2team.geharbang.domain.auth.entity.User;
+import com.ssg9th2team.geharbang.domain.auth.entity.UserSocial;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserSocialRepository extends JpaRepository<UserSocial, Long> {
+    
+    /// 소셜 로그인 제공자와 제공자 고유 ID로 사용자 소셜 정보 조회
+    Optional<UserSocial> findByProviderAndProviderUid(SocialProvider provider, String providerUid);
+    
+    /// 사용자 ID로 소셜 로그인 정보 조회
+    Optional<UserSocial> findByUserId(Long userId);
+
+    // 사용자로 모든 소셜 로그인 정보 조회
+    List<UserSocial> findByUser(User user);
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/service/AuthServiceImpl.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/service/AuthServiceImpl.java
@@ -9,6 +9,7 @@ import com.ssg9th2team.geharbang.domain.auth.dto.SignupRequest;
 import com.ssg9th2team.geharbang.domain.auth.dto.TokenResponse;
 import com.ssg9th2team.geharbang.domain.auth.dto.UserResponse;
 import com.ssg9th2team.geharbang.domain.auth.dto.VerifyCodeRequest;
+import com.ssg9th2team.geharbang.domain.auth.entity.SocialProvider;
 import com.ssg9th2team.geharbang.domain.auth.entity.User;
 import com.ssg9th2team.geharbang.domain.auth.entity.UserRole;
 import com.ssg9th2team.geharbang.domain.auth.repository.UserRepository;
@@ -85,6 +86,8 @@ public class AuthServiceImpl implements AuthService {
                         signupRequest.getMarketingAgreed() != null ? signupRequest.getMarketingAgreed() : false)
                 .hostApproved(null)
                 .themes(themes)
+                .socialProvider(SocialProvider.LOCAL)
+                .socialId(null)
                 .build();
 
         User savedUser = userRepository.save(user);

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/controller/UserController.java
@@ -4,6 +4,8 @@ import com.ssg9th2team.geharbang.domain.auth.dto.UserResponse;
 import com.ssg9th2team.geharbang.domain.auth.entity.User;
 import com.ssg9th2team.geharbang.domain.user.dto.DeleteAccountRequest;
 import com.ssg9th2team.geharbang.domain.user.service.UserService;
+import com.ssg9th2team.geharbang.domain.user.dto.UpdateProfileRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -22,6 +24,13 @@ public class UserController {
         String email = authentication.getName();
         User user = userService.getUserByEmail(email);
         return ResponseEntity.ok(UserResponse.from(user));
+    }
+
+    @PatchMapping("/me/profile")
+    public ResponseEntity<Void> updateUserProfile(Authentication authentication, @Valid @RequestBody UpdateProfileRequest request) {
+        String email = authentication.getName();
+        userService.updateUserProfile(email, request);
+        return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/me")

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/dto/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/dto/UpdateProfileRequest.java
@@ -1,0 +1,22 @@
+package com.ssg9th2team.geharbang.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProfileRequest {
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.")
+    private String nickname;
+
+    @NotBlank(message = "전화번호는 필수입니다.")
+    @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다. (010-1234-5678)")
+    private String phone;
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/service/UserService.java
@@ -3,9 +3,14 @@ package com.ssg9th2team.geharbang.domain.user.service;
 import com.ssg9th2team.geharbang.domain.auth.entity.User;
 import com.ssg9th2team.geharbang.domain.user.dto.DeleteAccountRequest;
 
+import com.ssg9th2team.geharbang.domain.user.dto.UpdateProfileRequest;
+
 public interface UserService {
     void deleteUser(String email, DeleteAccountRequest deleteAccountRequest);
 
     // 이메일로 사용자 정보 조회
     User getUserByEmail(String email);
+
+    // 사용자 프로필(닉네임, 전화번호) 업데이트
+    void updateUserProfile(String email, UpdateProfileRequest request);
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/service/UserServiceImpl.java
@@ -1,10 +1,13 @@
 package com.ssg9th2team.geharbang.domain.user.service;
 
 import com.ssg9th2team.geharbang.domain.auth.entity.User;
+import com.ssg9th2team.geharbang.domain.auth.entity.UserSocial;
 import com.ssg9th2team.geharbang.domain.auth.repository.UserRepository;
+import com.ssg9th2team.geharbang.domain.auth.repository.UserSocialRepository;
 import com.ssg9th2team.geharbang.domain.reservation.entity.Reservation;
 import com.ssg9th2team.geharbang.domain.reservation.repository.jpa.ReservationJpaRepository;
 import com.ssg9th2team.geharbang.domain.user.dto.DeleteAccountRequest;
+import com.ssg9th2team.geharbang.domain.user.dto.UpdateProfileRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,6 +21,7 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final ReservationJpaRepository reservationRepository;
+    private final UserSocialRepository userSocialRepository;
 
     @Override
     @Transactional
@@ -34,6 +38,12 @@ public class UserServiceImpl implements UserService {
             throw new IllegalStateException("진행 중이거나 완료된 예약이 있어 탈퇴할 수 없습니다. 모든 예약을 취소한 후 다시 시도해주세요.");
         }
 
+        // 연결된 소셜 로그인 정보 삭제
+        List<UserSocial> userSocials = userSocialRepository.findByUser(user);
+        if (!userSocials.isEmpty()) {
+            userSocialRepository.deleteAll(userSocials);
+            log.info("사용자 {}의 연결된 소셜 로그인 정보 {}개 삭제", email, userSocials.size());
+        }
 
         log.info("사용자 {} 탈퇴. 사유: {}, 기타: {}", email, deleteAccountRequest.getReasons(),
                 deleteAccountRequest.getOtherReason());
@@ -45,5 +55,18 @@ public class UserServiceImpl implements UserService {
     public User getUserByEmail(String email) {
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+    }
+
+    @Override
+    @Transactional
+    public void updateUserProfile(String email, UpdateProfileRequest request) {
+        User user = getUserByEmail(email);
+
+        // 닉네임 중복 확인 (자기 자신은 제외)
+        if (userRepository.existsByNicknameAndIdNot(request.getNickname(), user.getId())) {
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }
+
+        user.updateProfile(request.getNickname(), request.getPhone());
     }
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.ssg9th2team.geharbang.global.config;
 
+import com.ssg9th2team.geharbang.global.oauth.CustomOAuth2UserService;
+import com.ssg9th2team.geharbang.global.oauth.OAuth2AuthenticationSuccessHandler;
 import com.ssg9th2team.geharbang.global.security.JwtAuthenticationFilter;
 import com.ssg9th2team.geharbang.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +11,10 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -16,6 +22,8 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 @EnableWebSecurity
@@ -23,6 +31,9 @@ import java.util.Arrays;
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final ClientRegistrationRepository clientRegistrationRepository;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -43,13 +54,25 @@ public class SecurityConfig {
                                 "/api/auth/**",
                                 "/api/public/**",
                                 "/api/themes",
+                                "/api/themes/**",
+                                "/api/list/**",
                                 "/uploads/**",
                                 "/error",
+                                "/oauth2/**",
+                                "/login/oauth2/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**")
                         .permitAll()
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated())
+
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authorization -> authorization
+                                .authorizationRequestResolver(authorizationRequestResolver()))
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2AuthenticationSuccessHandler))
 
                 // JWT 인증 필터 추가
                 .addFilterBefore(
@@ -57,6 +80,27 @@ public class SecurityConfig {
                         UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    // 네이버 OAuth2 재인증 강제를 위한 커스텀 리졸버
+    @Bean
+    public OAuth2AuthorizationRequestResolver authorizationRequestResolver() {
+        DefaultOAuth2AuthorizationRequestResolver resolver = 
+                new DefaultOAuth2AuthorizationRequestResolver(
+                        clientRegistrationRepository, 
+                        "/oauth2/authorization");
+        
+        resolver.setAuthorizationRequestCustomizer(customizer -> {
+            OAuth2AuthorizationRequest.Builder builder = customizer;
+            
+            // 네이버 OAuth2의 경우 auth_type=reauthenticate 파라미터 추가
+            Map<String, Object> additionalParameters = new HashMap<>(builder.build().getAdditionalParameters());
+            additionalParameters.put("auth_type", "reauthenticate"); // 네이버 재인증 강제
+            
+            builder.additionalParameters(additionalParameters);
+        });
+        
+        return resolver;
     }
 
     @Bean

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/CustomOAuth2User.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/CustomOAuth2User.java
@@ -1,0 +1,46 @@
+package com.ssg9th2team.geharbang.global.oauth;
+
+import com.ssg9th2team.geharbang.domain.auth.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    private User user;
+    private Map<String, Object> attributes;
+
+    public CustomOAuth2User(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(user.getRole().getKey()));
+    }
+
+    @Override
+    public String getName() {
+        return user.getEmail();
+    }
+
+    public String getEmail() {
+        return user.getEmail();
+    }
+
+    public Long getUserId() {
+        return user.getId();
+    }
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,146 @@
+package com.ssg9th2team.geharbang.global.oauth;
+
+import com.ssg9th2team.geharbang.domain.auth.entity.SocialProvider;
+import com.ssg9th2team.geharbang.domain.auth.entity.User;
+import com.ssg9th2team.geharbang.domain.auth.entity.UserRole;
+import com.ssg9th2team.geharbang.domain.auth.entity.UserSocial;
+import com.ssg9th2team.geharbang.domain.auth.repository.UserRepository;
+import com.ssg9th2team.geharbang.domain.auth.repository.UserSocialRepository;
+import com.ssg9th2team.geharbang.domain.user.entity.Gender;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final UserSocialRepository userSocialRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        log.info("OAuth2 Login - Provider: {}", registrationId);
+
+        OAuth2UserInfo oAuth2UserInfo = null;
+
+        if ("naver".equals(registrationId)) {
+            oAuth2UserInfo = new NaverOAuth2UserInfo(oAuth2User.getAttributes());
+        } else {
+            throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다: " + registrationId);
+        }
+
+        String providerId = oAuth2UserInfo.getProviderId();
+        String provider = oAuth2UserInfo.getProvider();
+        String email = oAuth2UserInfo.getEmail();
+        String name = oAuth2UserInfo.getName();
+        String genderStr = oAuth2UserInfo.getGender();
+        String mobile = oAuth2UserInfo.getMobile();
+
+        log.info("OAuth2 User Info - Provider: {}, ProviderId: {}, Email: {}, Name: {}, Gender: {}, Mobile: {}",
+                provider, providerId, email, name, genderStr, mobile);
+
+        SocialProvider socialProvider = SocialProvider.valueOf(provider.toUpperCase());
+
+        // 1. user_social 테이블에서 기존 소셜 로그인 정보 조회
+        Optional<UserSocial> userSocialOptional = userSocialRepository.findByProviderAndProviderUid(
+                socialProvider,
+                providerId
+        );
+
+        User user;
+        if (userSocialOptional.isEmpty()) {
+            // 신규 소셜 로그인 사용자
+            log.info("신규 소셜 로그인 사용자 생성: {}", email);
+
+            // 이메일 중복 체크 (일반 회원가입으로 이미 가입된 경우)
+            Optional<User> existingUser = userRepository.findByEmail(email);
+            
+            if (existingUser.isPresent()) {
+                // 이메일은 이미 있지만 소셜 로그인은 처음인 경우
+                // 기존 User에 소셜 계정 연결
+                user = existingUser.get();
+                log.info("기존 사용자에 소셜 계정 연결: {}", email);
+            } else {
+                // 완전히 새로운 사용자 생성
+                Gender gender = convertGender(genderStr);
+
+                user = User.builder()
+                        .name(name)
+                        .nickname(generateUniqueNickname(name))
+                        .gender(gender)
+                        .email(email)
+                        .password(null) // 소셜 로그인은 비밀번호 없음
+                        .phone(mobile)
+                        .role(UserRole.USER)
+                        .marketingAgreed(false)
+                        .hostApproved(null)
+                        .socialProvider(null) // User 테이블의 socialProvider는 사용하지 않음
+                        .socialId(null) // User 테이블의 socialId는 사용하지 않음
+                        .build();
+
+                user = userRepository.save(user);
+                log.info("신규 사용자 생성 완료: {}", user.getEmail());
+            }
+
+            // user_social 테이블에 소셜 로그인 정보 저장
+            UserSocial userSocial = UserSocial.builder()
+                    .user(user)
+                    .provider(socialProvider)
+                    .providerUid(providerId)
+                    .email(email)
+                    .profileImage(null) // 네이버 API에서 프로필 이미지를 받아올 수 있다면 여기에 설정
+                    .build();
+
+            userSocialRepository.save(userSocial);
+            log.info("소셜 로그인 정보 저장 완료: provider={}, uid={}", socialProvider, providerId);
+        } else {
+            // 기존 소셜 로그인 사용자
+            UserSocial userSocial = userSocialOptional.get();
+            user = userSocial.getUser();
+            log.info("기존 소셜 로그인 사용자 로그인: {}", user.getEmail());
+        }
+
+        return new CustomOAuth2User(user, oAuth2User.getAttributes());
+    }
+
+    private String generateUniqueNickname(String baseName) {
+        String nickname = baseName;
+        int count = 1;
+        while (userRepository.existsByNickname(nickname)) {
+            nickname = baseName + count;
+            count++;
+        }
+        return nickname;
+    }
+
+    /**
+     * 네이버 성별 정보를 Gender enum으로 변환
+     * @param genderStr 네이버 성별 ("M", "F", "U" 또는 null)
+     * @return Gender enum (MALE, FEMALE, 또는 null)
+     */
+    private Gender convertGender(String genderStr) {
+        if (genderStr == null) {
+            return null;
+        }
+        
+        return switch (genderStr) {
+            case "M" -> Gender.MALE;
+            case "F" -> Gender.FEMALE;
+            default -> null; // "U" (미확인) 또는 기타 값은 null
+        };
+    }
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/NaverOAuth2UserInfo.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/NaverOAuth2UserInfo.java
@@ -1,0 +1,64 @@
+package com.ssg9th2team.geharbang.global.oauth;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo implements OAuth2UserInfo {
+
+    private Map<String, Object> attributes;
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        if (response == null) {
+            return null;
+        }
+        return (String) response.get("id");
+    }
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        if (response == null) {
+            return null;
+        }
+        return (String) response.get("email");
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        if (response == null) {
+            return null;
+        }
+        return (String) response.get("name");
+    }
+
+    @Override
+    public String getGender() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        if (response == null) {
+            return null;
+        }
+        // 네이버는 "M", "F", "U" (미확인) 형식으로 성별 정보 제공
+        return (String) response.get("gender");
+    }
+
+    @Override
+    public String getMobile() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        if (response == null) {
+            return null;
+        }
+        // 네이버는 'mobile' 필드로 휴대전화번호 제공
+        return (String) response.get("mobile");
+    }
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/OAuth2AuthenticationSuccessHandler.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,56 @@
+package com.ssg9th2team.geharbang.global.oauth;
+
+import com.ssg9th2team.geharbang.global.security.JwtTokenProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Value("${oauth2.redirect-uri:http://localhost:3000/oauth2/redirect}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        String targetUrl = determineTargetUrl(request, response, authentication);
+
+        if (response.isCommitted()) {
+            log.debug("Response has already been committed. Unable to redirect to " + targetUrl);
+            return;
+        }
+
+        clearAuthenticationAttributes(request);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) {
+        // JWT 토큰 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(authentication);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(authentication);
+
+        log.info("OAuth2 Login Success - User: {}", authentication.getName());
+
+        // 프론트엔드 리다이렉트 URL에 토큰 포함
+        return UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build()
+                .toUriString();
+    }
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/OAuth2UserInfo.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/OAuth2UserInfo.java
@@ -1,0 +1,12 @@
+package com.ssg9th2team.geharbang.global.oauth;
+
+import java.util.Map;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getProvider();
+    String getEmail();
+    String getName();
+    String getGender(); // 성별 정보 추가
+    String getMobile(); // 전화번호 정보 추가
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -80,3 +80,19 @@ ncloud.storage.bucket=${NCLOUD_BUCKET:gusethouse}
 ncloud.storage.access-key=${NCLOUD_ACCESS_KEY}
 ncloud.storage.secret-key=${NCLOUD_SECRET_KEY}
 
+
+# Naver OAuth2 Login (Spring Security OAuth2 Client)
+spring.security.oauth2.client.registration.naver.client-id=AhIOfE97qqgtD3U2k5ha
+spring.security.oauth2.client.registration.naver.client-secret=1fcrurYkNk
+spring.security.oauth2.client.registration.naver.redirect-uri=http://localhost:8080/login/oauth2/code/naver
+spring.security.oauth2.client.registration.naver.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.naver.scope=name,email
+spring.security.oauth2.client.registration.naver.client-name=Naver
+
+spring.security.oauth2.client.provider.naver.authorization-uri=https://nid.naver.com/oauth2.0/authorize
+spring.security.oauth2.client.provider.naver.token-uri=https://nid.naver.com/oauth2.0/token
+spring.security.oauth2.client.provider.naver.user-info-uri=https://openapi.naver.com/v1/nid/me
+spring.security.oauth2.client.provider.naver.user-name-attribute=response
+
+# OAuth2 Redirect URI (for frontend)
+oauth2.redirect-uri=http://localhost:5173/oauth2/redirect

--- a/frontend/src/api/authClient.js
+++ b/frontend/src/api/authClient.js
@@ -230,6 +230,13 @@ export async function authenticatedRequest(endpoint, options = {}) {
   return response
 }
 
+// 현재 로그인한 사용자 정보 조회
+export async function getCurrentUser() {
+  return authenticatedRequest('/api/users/me', {
+    method: 'GET'
+  })
+}
+
 export default {
   signup,
   login,
@@ -244,6 +251,7 @@ export default {
   checkNicknameDuplicate,
   refreshAccessToken,
   authenticatedRequest,
+  getCurrentUser,
   getAccessToken,
   getRefreshToken,
   getUserInfo,

--- a/frontend/src/api/userClient.js
+++ b/frontend/src/api/userClient.js
@@ -7,6 +7,14 @@ export async function getCurrentUser() {
   });
 }
 
+// 사용자 프로필(닉네임, 전화번호) 업데이트
+export async function updateUserProfile(profileData) {
+  return authenticatedRequest('/api/users/me/profile', {
+    method: 'PATCH',
+    body: JSON.stringify(profileData),
+  });
+}
+
 // 본인 계정 삭제
 export async function deleteSelf(reasons, otherReason) {
   return authenticatedRequest('/api/users/me', {

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -135,6 +135,11 @@ const router = createRouter({
             component: () => import('../views/LoginView/ResetPasswordSuccessView.vue')
         },
         {
+            path: '/oauth2/redirect',
+            name: 'oauth2-redirect',
+            component: () => import('../views/LoginView/OAuth2RedirectHandler.vue')
+        },
+        {
             path: '/host',
             name: 'host-dashboard',
             component: () => import('../views/HostView/HostDashboardView.vue'),

--- a/frontend/src/views/LoginView/LoginView.vue
+++ b/frontend/src/views/LoginView/LoginView.vue
@@ -72,18 +72,21 @@ const handleLogin = async () => {
 }
 
 const socialLogin = (provider) => {
-  // 실제 구현 시 각 provider의 OAuth URL로 리다이렉트
+  // 백엔드 OAuth2 URL로 리다이렉트
+  const baseUrl = 'http://localhost:8080'
   const urls = {
-    Google: 'https://accounts.google.com/o/oauth2/v2/auth', // 예시 URL 추가해야됨
-    Kakao: 'https://kauth.kakao.com/oauth/authorize', // 예시 URL
-    Naver: 'https://nid.naver.com/oauth2.0/authorize' // 예시 URL
+    Google: `${baseUrl}/oauth2/authorization/google`, // Google OAuth2 (구현 필요)
+    Kakao: `${baseUrl}/oauth2/authorization/kakao`, // Kakao OAuth2 (구현 필요)
+    Naver: `${baseUrl}/oauth2/authorization/naver` // Naver OAuth2 (구현 완료)
   }
 
-  // 개발 중에는 모달로 표시
-  openModal(`${provider} 로그인으로 이동합니다.`, 'info')
-
-  // 실제 구현 시 주석 해제
-  // window.location.href = urls[provider]
+  if (provider === 'Naver') {
+    // 네이버 로그인은 구현되어 있으므로 바로 리다이렉트
+    window.location.href = urls[provider]
+  } else {
+    // 다른 소셜 로그인은 아직 구현되지 않음
+    openModal(`${provider} 로그인은 준비 중입니다.`, 'info')
+  }
 }
 
 const goToSignup = () => {

--- a/frontend/src/views/LoginView/OAuth2RedirectHandler.vue
+++ b/frontend/src/views/LoginView/OAuth2RedirectHandler.vue
@@ -1,0 +1,178 @@
+<script setup>
+import { onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { saveUserInfo } from '@/api/authClient'
+
+const router = useRouter()
+const loading = ref(true)
+const error = ref(null)
+
+// JWT 토큰 디코딩 함수
+const decodeJWT = (token) => {
+  try {
+    const base64Url = token.split('.')[1]
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    )
+    return JSON.parse(jsonPayload)
+  } catch (e) {
+    console.error('JWT 디코딩 실패:', e)
+    return null
+  }
+}
+
+onMounted(async () => {
+  try {
+    // URL에서 토큰 파라미터 추출
+    const urlParams = new URLSearchParams(window.location.search)
+    const accessToken = urlParams.get('accessToken')
+    const refreshToken = urlParams.get('refreshToken')
+
+    if (!accessToken || !refreshToken) {
+      throw new Error('토큰을 받지 못했습니다.')
+    }
+
+    // 토큰 저장
+    localStorage.setItem('accessToken', accessToken)
+    localStorage.setItem('refreshToken', refreshToken)
+
+    // JWT 토큰에서 사용자 정보 추출
+    const decoded = decodeJWT(accessToken)
+    if (decoded) {
+      const userInfo = {
+        email: decoded.sub, // JWT의 subject에 이메일이 저장됨
+        role: decoded.authorities?.[0]?.replace('ROLE_', '') || 'USER' // 권한에서 역할 추출
+      }
+      saveUserInfo(userInfo)
+    }
+
+    // 로그인 성공 - 홈으로 리다이렉트
+    setTimeout(() => {
+      router.push('/')
+    }, 1000)
+  } catch (err) {
+    console.error('OAuth2 로그인 처리 중 오류:', err)
+    error.value = err.message || '소셜 로그인에 실패했습니다.'
+
+    // 3초 후 로그인 페이지로 리다이렉트
+    setTimeout(() => {
+      router.push('/login')
+    }, 3000)
+  } finally {
+    loading.value = false
+  }
+})
+</script>
+
+<template>
+  <div class="oauth2-redirect-page">
+    <div class="redirect-container">
+      <div v-if="loading" class="loading-state">
+        <div class="spinner"></div>
+        <h2>로그인 처리 중...</h2>
+        <p>잠시만 기다려주세요</p>
+      </div>
+
+      <div v-else-if="error" class="error-state">
+        <div class="error-icon">✕</div>
+        <h2>로그인 실패</h2>
+        <p>{{ error }}</p>
+        <p class="redirect-info">로그인 페이지로 이동합니다...</p>
+      </div>
+
+      <div v-else class="success-state">
+        <div class="success-icon">✓</div>
+        <h2>로그인 성공!</h2>
+        <p>메인 페이지로 이동합니다...</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.oauth2-redirect-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f9fafb;
+}
+
+.redirect-container {
+  background: white;
+  padding: 3rem 2rem;
+  border-radius: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+  max-width: 400px;
+  width: 100%;
+  text-align: center;
+}
+
+.loading-state,
+.error-state,
+.success-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.spinner {
+  width: 50px;
+  height: 50px;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #00796b;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.success-icon,
+.error-icon {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.success-icon {
+  background: #a5d6a7;
+  color: #2e7d32;
+}
+
+.error-icon {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #333;
+  margin: 0;
+}
+
+p {
+  font-size: 0.95rem;
+  color: #666;
+  margin: 0;
+}
+
+.redirect-info {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: #888;
+}
+</style>

--- a/frontend/src/views/home/HomeView.vue
+++ b/frontend/src/views/home/HomeView.vue
@@ -1,4 +1,4 @@
-﻿<script setup>
+<script setup>
 import { onMounted, ref } from 'vue'
 import GuesthouseCard from '../../components/GuesthouseCard.vue'
 import { useRouter } from 'vue-router'
@@ -89,9 +89,14 @@ const loadSections = async () => {
     let preferredThemes = []
 
     if (isAuthenticated()) {
-      const preferredResponse = await fetchUserThemes()
-      if (preferredResponse.ok && Array.isArray(preferredResponse.data)) {
-        preferredThemes = preferredResponse.data
+      try {
+        const preferredResponse = await fetchUserThemes()
+        if (preferredResponse.ok && Array.isArray(preferredResponse.data)) {
+          preferredThemes = preferredResponse.data
+        }
+      } catch (err) {
+        console.warn('Failed to fetch user themes, continuing with all themes:', err)
+        // 사용자 선호 테마를 불러오지 못해도 전체 테마 목록은 표시
       }
     }
 

--- a/frontend/src/views/home/HomeView.vue.backup_header
+++ b/frontend/src/views/home/HomeView.vue.backup_header
@@ -1,0 +1,4 @@
+﻿<script setup>
+import { onMounted, ref } from 'vue'
+import GuesthouseCard from '../../components/GuesthouseCard.vue'
+import { useRouter } from 'vue-router'


### PR DESCRIPTION
    💡 PR 제목
  feat: [Mypage] 프로필 수정 기능 구현 및 인증/탈퇴 로직 개선

  ---

  🔗 관련 이슈
   - Refs/Closes: #126 

  ---

  📌 작업 내용 요약
   - [x] 마이페이지에서 닉네임, 전화번호를 수정하는 기능 추가
   - [x] 회원 탈퇴 시 데이터베이스 제약 조건으로 실패하던 오류 수정
   - [x] 소셜 로그인 시 전화번호가 누락되던 버그 수정
   - [x] 프로필 수정 UI/UX 개선 (전화번호 자동 하이픈, 실시간 유효성 검사)

  ---

  🧱 변경 범위 (Scope)
  Backend
   - [x] API 추가/수정
   - [x] Validation/예외처리
   - [ ] 인증/인가
   - [x] DB 스키마/쿼리 (Repository 메소드 추가)
   - [ ] 기타:

  Frontend
   - [x] UI/라우팅 (마이페이지 UI 수정)
   - [x] 상태관리/비동기 로직 (API 연동 및 로컬 상태 관리)
   - [x] 입력값/검증 (닉네임, 전화번호 클라이언트단 유효성 검사)
   - [ ] 기타:

  ---

  🧪 테스트 내역
  Backend
   - [x] 로컬에서 애플리케이션 실행 확인 (DB 연결 문제 해결 후)
   - [ ] 단위 테스트 통과
   - [x] API 수동 테스트 (Postman / Swagger 등)

  Frontend
   - [x] npm run dev 로컬 실행 확인
   - [x] 주요 화면/기능 수동 테스트

  테스트 상세(필수)
   - 소셜 로그인 신규 가입 시 전화번호 저장 확인
   - 마이페이지 진입 > '수정' 버튼 클릭 > 닉네임 및 전화번호 수정
   - 닉네임/전화번호 형식 오류 시, 실시간 에러 메시지 노출 확인
   - 정상 형식 입력 후 '저장' 시, 프로필 정보가 업데이트 되는지 확인
   - 회원 탈퇴 시도 (예약 없는 사용자) > 정상 탈퇴 성공 확인
   - 회원 탈퇴 시도 (예약 있는 사용자) > '예약이 있어 탈퇴 불가' 메시지 확인

  ---

  🖼️ 화면 캡처 / 시연 영상 (Frontend 변경 시 권장)
   - before:
     - 프로필 정보가 텍스트로만 표시되며 수정 불가
     - 전화번호 입력 시 유효성 검사나 자동 서식 없음
   - after:
     - '수정' 버튼 추가 및 클릭 시 닉네임/전화번호가 입력 필드로 전환
     - 전화번호 입력 시 010-XXXX-XXXX 자동 하이픈 및 길이 제한 적용
     - 형식 오류 시 입력 필드 하단에 실시간 에러 메시지 노출

  ---

  ⚠️ 영향도 / 리스크 / 롤백
   - 영향도: 기존 회원 탈퇴 API의 실패 응답이 500 Internal Server Error에서 명확한 사유를 포함한 4xx 에러로 변경
   - 리스크: 없음
   - 롤백 방법: 해당 PR revert 커밋

  ---
