### PR TITLE
feat : 소셜로그인 회원가입 절차 변경 및 로그인 및 로그아웃시 버그 수정, 리프래시 토큰 수정

### DIFF
--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/CompleteSocialSignupRequest.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/CompleteSocialSignupRequest.java
@@ -1,0 +1,21 @@
+package com.ssg9th2team.geharbang.domain.auth.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CompleteSocialSignupRequest {
+
+    @NotNull(message = "약관 동의 상태는 필수입니다.")
+    private Boolean termsAgreed; // 필수 약관 동의 여부
+
+    private Boolean marketingAgreed; // 마케팅 정보 수신 동의
+
+    private List<Long> themeIds; // 관심 테마 ID 목록
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/User.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/User.java
@@ -62,6 +62,9 @@ public class User {
     @Column(name = "host_approved")
     private Boolean hostApproved; // 호스트 숙소 등록 승인 상태 (1: 승인됨, 0: 승인 거절, NULL: 일반 USER)
 
+    @Column(name = "social_signup_completed")
+    private Boolean socialSignupCompleted; // 소셜 로그인 회원가입 완료 여부 (true: 완료, false: 미완료, NULL: 일반 회원가입)
+
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -79,7 +82,7 @@ public class User {
     private Set<Theme> themes = new HashSet<>();
 
     @Builder
-    public User(String name, String nickname, Gender gender, String email, String password, String phone, UserRole role, Boolean marketingAgreed, Boolean hostApproved, Set<Theme> themes, SocialProvider socialProvider, String socialId) {
+    public User(String name, String nickname, Gender gender, String email, String password, String phone, UserRole role, Boolean marketingAgreed, Boolean hostApproved, Boolean socialSignupCompleted, Set<Theme> themes, SocialProvider socialProvider, String socialId) {
         this.name = name;
         this.nickname = nickname;
         this.gender = gender;
@@ -89,6 +92,7 @@ public class User {
         this.role = role != null ? role : UserRole.USER;
         this.marketingAgreed = marketingAgreed != null ? marketingAgreed : false;
         this.hostApproved = hostApproved;
+        this.socialSignupCompleted = socialSignupCompleted;
         this.themes = themes;
         this.socialProvider = socialProvider;
         this.socialId = socialId;
@@ -120,5 +124,14 @@ public class User {
     // 호스트 승인 상태 변경
     public void updateHostApproved(Boolean approved) {
         this.hostApproved = approved;
+    }
+
+    // 소셜 회원가입 완료 처리
+    public void completeSocialSignup(Boolean marketingAgreed, Set<Theme> themes) {
+        this.socialSignupCompleted = true;
+        this.marketingAgreed = marketingAgreed != null ? marketingAgreed : false;
+        if (themes != null) {
+            this.themes = themes;
+        }
     }
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/service/AuthService.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.ssg9th2team.geharbang.domain.auth.service;
 
+import com.ssg9th2team.geharbang.domain.auth.dto.CompleteSocialSignupRequest;
 import com.ssg9th2team.geharbang.domain.auth.dto.FindEmailRequest;
 import com.ssg9th2team.geharbang.domain.auth.dto.FindEmailResponse;
 import com.ssg9th2team.geharbang.domain.auth.dto.FindPasswordRequest;
@@ -44,4 +45,7 @@ public interface AuthService {
 
     // 리프레시 토큰으로 액세스 토큰 재발급
     TokenResponse refresh(String refreshToken);
+
+    // 소셜 회원가입 완료
+    UserResponse completeSocialSignup(Long userId, CompleteSocialSignupRequest request);
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/theme/dto/ThemeDto.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/theme/dto/ThemeDto.java
@@ -1,0 +1,18 @@
+package com.ssg9th2team.geharbang.domain.theme.dto;
+
+import com.ssg9th2team.geharbang.domain.theme.entity.Theme;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ThemeDto {
+    private Long id;
+    private String name;
+
+    public static ThemeDto of(Theme theme) {
+        return new ThemeDto(theme.getId(), theme.getThemeName());
+    }
+}

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/config/SecurityConfig.java
@@ -54,7 +54,6 @@ public class SecurityConfig {
                                 "/api/auth/**",
                                 "/api/public/**",
                                 "/api/themes",
-                                "/api/themes/**",
                                 "/api/list/**",
                                 "/uploads/**",
                                 "/error",

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/CustomOAuth2UserService.java
@@ -88,6 +88,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                         .role(UserRole.USER)
                         .marketingAgreed(false)
                         .hostApproved(null)
+                        .socialSignupCompleted(false) // 소셜 회원가입 미완료 상태
                         .socialProvider(null) // User 테이블의 socialProvider는 사용하지 않음
                         .socialId(null) // User 테이블의 socialId는 사용하지 않음
                         .build();

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/security/JwtAuthenticationFilter.java
@@ -25,7 +25,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final List<String> EXCLUDE_PATHS = Arrays.asList(
             "/api/auth/",
             "/api/public/",
-            "/api/themes",
             "/uploads/",
             "/error",
             "/oauth2/",
@@ -34,12 +33,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/v3/api-docs/"
     );
 
+    // JWT 검증을 건너뛸 정확한 경로 목록 (startsWith가 아닌 equals로 비교)
+    private static final List<String> EXACT_EXCLUDE_PATHS = Arrays.asList(
+            "/api/themes"
+    );
+
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        
-        // EXCLUDE_PATHS에 포함된 경로는 JWT 필터링 건너뛰기
-        return EXCLUDE_PATHS.stream().anyMatch(path::startsWith);
+
+        // EXCLUDE_PATHS에 포함된 경로로 시작하는 경우 JWT 필터링 건너뛰기
+        boolean startsWithExclude = EXCLUDE_PATHS.stream().anyMatch(path::startsWith);
+
+        // EXACT_EXCLUDE_PATHS와 정확히 일치하는 경우 JWT 필터링 건너뛰기
+        boolean equalsExclude = EXACT_EXCLUDE_PATHS.stream().anyMatch(path::equals);
+
+        return startsWithExclude || equalsExclude;
     }
 
     @Override

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -64,7 +64,7 @@ tosspayments.client-key=test_gck_docs_Ovk5rk1EwkEbP0W43n07xlzm
 # JWT
 jwt.secret=+cTSQUBeGrv7lZeDduUU2CYuq9B2cgV72uQx6MoyCOwpdz80ZpQUsGshRfmIeKPNlrGCap35nQUBydvReN5Muw==
 jwt.access-token-expiration=3600000
-jwt.refresh-token-expiration=604800000
+jwt.refresh-token-expiration=1800000
 
 # Mail Server Settings (for Email Verification)
 spring.mail.host=smtp.gmail.com
@@ -105,3 +105,4 @@ ncp.chatbot.signature-secret=${NCLOUD_CHATBOT_SIGNATURE_SECRET}
 
 # OAuth2 Redirect URI (for frontend)
 oauth2.redirect-uri=http://localhost:5173/oauth2/redirect
+oauth2.signup-redirect-uri=http://localhost:5173/social-signup

--- a/backend/src/test/java/com/ssg9th2team/geharbang/domain/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/ssg9th2team/geharbang/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,137 @@
+package com.ssg9th2team.geharbang.domain.auth.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssg9th2team.geharbang.domain.auth.dto.LoginRequest;
+import com.ssg9th2team.geharbang.domain.auth.entity.User;
+import com.ssg9th2team.geharbang.domain.auth.entity.UserRole;
+import com.ssg9th2team.geharbang.domain.auth.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll(); // Clean up previous test data
+
+        testUser = User.builder()
+                .email("testuser@example.com")
+                .password(passwordEncoder.encode("password123"))
+                .nickname("testuser")
+                .role(UserRole.USER)
+                .marketingAgreed(false)
+                .build();
+        userRepository.save(testUser);
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void loginSuccess() throws Exception {
+        // given
+        LoginRequest loginRequest = new LoginRequest("testuser@example.com", "password123");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.refreshToken").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 잘못된 비밀번호")
+    void loginFail_WrongPassword() throws Exception {
+        // given
+        LoginRequest loginRequest = new LoginRequest("testuser@example.com", "wrongpassword");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)));
+
+        // then
+        result.andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 존재하지 않는 사용자")
+    void loginFail_UserNotFound() throws Exception {
+        // given
+        LoginRequest loginRequest = new LoginRequest("nouser@example.com", "password123");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)));
+
+        // then
+        result.andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 이메일 형식 오류")
+    void loginFail_InvalidEmailFormat() throws Exception {
+        // given
+        LoginRequest loginRequest = new LoginRequest("testuser@", "password123");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호 누락")
+    void loginFail_MissingPassword() throws Exception {
+        // given
+        LoginRequest loginRequest = new LoginRequest("testuser@example.com", "");
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)));
+
+        // then
+        result.andExpect(status().isBadRequest());
+    }
+}

--- a/frontend/src/api/authClient.js
+++ b/frontend/src/api/authClient.js
@@ -1,12 +1,11 @@
-// Auth API client for login, signup, token management
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
 
-// LocalStorage keys
+
 const ACCESS_TOKEN_KEY = 'accessToken'
 const REFRESH_TOKEN_KEY = 'refreshToken'
 const USER_INFO_KEY = 'userInfo'
 
-// Get tokens from localStorage
 export function getAccessToken() {
   return localStorage.getItem(ACCESS_TOKEN_KEY)
 }
@@ -20,30 +19,30 @@ export function getUserInfo() {
   return userInfo ? JSON.parse(userInfo) : null
 }
 
-// Save tokens to localStorage
+
 export function saveTokens(accessToken, refreshToken) {
   localStorage.setItem(ACCESS_TOKEN_KEY, accessToken)
   localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken)
 }
 
-// Save user info to localStorage
+
 export function saveUserInfo(userInfo) {
   localStorage.setItem(USER_INFO_KEY, JSON.stringify(userInfo))
 }
 
-// Clear all auth data
+
 export function clearAuth() {
   localStorage.removeItem(ACCESS_TOKEN_KEY)
   localStorage.removeItem(REFRESH_TOKEN_KEY)
   localStorage.removeItem(USER_INFO_KEY)
 }
 
-// Check if user is logged in
+
 export function isAuthenticated() {
   return !!getAccessToken()
 }
 
-// API request helper
+
 async function apiRequest(endpoint, options = {}) {
   const url = `${API_BASE_URL}${endpoint}`
   const headers = {
@@ -51,7 +50,7 @@ async function apiRequest(endpoint, options = {}) {
     ...(options.headers || {})
   }
 
-  // Add Authorization header if access token exists
+
   const accessToken = getAccessToken()
   if (accessToken && !options.skipAuth) {
     headers.Authorization = `Bearer ${accessToken}`
@@ -237,6 +236,14 @@ export async function getCurrentUser() {
   })
 }
 
+// 소셜 회원가입 완료
+export async function completeSocialSignup(signupData) {
+  return authenticatedRequest('/api/auth/complete-social-signup', {
+    method: 'POST',
+    body: JSON.stringify(signupData)
+  })
+}
+
 export default {
   signup,
   login,
@@ -252,6 +259,7 @@ export default {
   refreshAccessToken,
   authenticatedRequest,
   getCurrentUser,
+  completeSocialSignup,
   getAccessToken,
   getRefreshToken,
   getUserInfo,

--- a/frontend/src/api/theme.js
+++ b/frontend/src/api/theme.js
@@ -1,9 +1,9 @@
-import { hostGet } from './adminClient'
+import { authenticatedRequest } from './authClient'
 
 export async function fetchThemes() {
-  return hostGet('/themes')
+  return authenticatedRequest('/api/themes', { method: 'GET', skipAuth: true })
 }
 
 export async function fetchUserThemes() {
-  return hostGet('/themes/me')
+  return authenticatedRequest('/api/themes/me', { method: 'GET' })
 }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -115,6 +115,16 @@ const router = createRouter({
             component: () => import('../views/RegisterView/RegisterView.vue')
         },
         {
+            path: '/social-signup',
+            name: 'social-signup',
+            component: () => import('../views/SocialSignupView/SocialSignupView.vue')
+        },
+        {
+            path: '/oauth2/redirect',
+            name: 'oauth-redirect',
+            component: () => import('../views/OAuth2RedirectView/OAuth2RedirectView.vue')
+        },
+        {
             path: '/find-email',
             name: 'find-email',
             component: () => import('../views/LoginView/FindEmailView.vue')

--- a/frontend/src/views/OAuth2RedirectView/OAuth2RedirectView.vue
+++ b/frontend/src/views/OAuth2RedirectView/OAuth2RedirectView.vue
@@ -1,0 +1,77 @@
+<script setup>
+import { onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { saveTokens } from '@/api/authClient'
+
+const router = useRouter()
+const route = useRoute()
+
+onMounted(async () => {
+  // URL 파라미터에서 토큰 추출
+  const accessToken = route.query.accessToken
+  const refreshToken = route.query.refreshToken
+
+  if (!accessToken || !refreshToken) {
+    console.error('토큰이 없습니다.')
+    router.push('/login')
+    return
+  }
+
+  // 토큰 저장
+  saveTokens(accessToken, refreshToken)
+
+  // 현재 경로 확인하여 리다이렉트
+  // /oauth2/redirect는 기존 사용자, /social-signup는 신규 사용자
+  // OAuth2AuthenticationSuccessHandler에서 이미 분기 처리되어 리다이렉트됨
+
+  // 메인 페이지로 이동 (기존 소셜 사용자)
+  router.push('/')
+})
+</script>
+
+<template>
+  <div class="redirect-page">
+    <div class="loading-container">
+      <div class="spinner"></div>
+      <p>로그인 처리 중...</p>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.redirect-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f9fafb;
+}
+
+.loading-container {
+  text-align: center;
+}
+
+.spinner {
+  width: 50px;
+  height: 50px;
+  margin: 0 auto 1rem;
+  border: 4px solid #e5e7eb;
+  border-top: 4px solid #333;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-container p {
+  font-size: 1rem;
+  color: #666;
+}
+</style>

--- a/frontend/src/views/SocialSignupView/SocialSignupView.vue
+++ b/frontend/src/views/SocialSignupView/SocialSignupView.vue
@@ -1,0 +1,740 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { completeSocialSignup, saveTokens } from '@/api/authClient'
+
+const router = useRouter()
+const route = useRoute()
+const currentStep = ref(1)
+const isLoading = ref(false)
+
+// 페이지 로드 시 토큰 저장
+onMounted(() => {
+  const accessToken = route.query.accessToken
+  const refreshToken = route.query.refreshToken
+
+  if (accessToken && refreshToken) {
+    // 토큰 저장
+    saveTokens(accessToken, refreshToken)
+    console.log('소셜 로그인 토큰 저장 완료')
+  } else {
+    console.error('토큰이 없습니다. 로그인 페이지로 이동합니다.')
+    router.push('/login')
+  }
+})
+
+// Step 1: Terms Agreement
+const allAgreed = ref(false)
+const terms = ref([
+  { id: 1, label: '(필수) 서비스 이용약관', required: true, checked: false, content: `
+    제1조 (목적)<br/>
+    본 약관은 [회사명]이 제공하는 게스트하우스 예약 플랫폼 서비스(이하 "서비스")의 이용과 관련하여 회사와 회원 간의 권리, 의무 및 책임사항을 규정함을 목적으로 합니다.<br/><br/>
+
+    제2조 (서비스의 내용)<br/>
+    서비스는 게스트하우스 정보 검색, 예약 및 결제, 후기 작성, 마이페이지를 통한 예약 관리 등의 기능을 제공합니다. 회사는 통신판매중개자로서, 실제 숙박 서비스는 호스트(숙소 운영자)가 제공합니다.<br/><br/>
+
+    제3조 (회원의 의무)<br/>
+    1. 회원은 본 약관 및 관계 법령을 준수해야 합니다.<br/>
+    2. 회원은 정확한 정보를 제공해야 하며, 허위 정보로 인해 발생하는 불이익에 대한 책임은 회원에게 있습니다.<br/>
+    3. 회원은 서비스 이용과 관련하여 다음 행위를 하여서는 안 됩니다:<br/>
+       - 허위 정보 등록<br/>
+       - 타인의 정보 도용<br/>
+       - 서비스의 정상적인 운영 방해<br/>
+       - 회사의 지식재산권 침해<br/>
+       - 기타 불법적이거나 부당한 행위<br/><br/>
+
+    제4조 (예약 및 결제)<br/>
+    1. 회원은 서비스를 통해 게스트하우스 예약을 요청할 수 있으며, 회사는 호스트를 대신하여 예약 접수 및 결제를 중개합니다.<br/>
+    2. 예약 확정 및 결제 완료 시, 회원과 호스트 간에 숙박 계약이 체결됩니다.<br/>
+    3. 예약 취소 및 환불 정책은 각 숙소의 정책 또는 회사의 표준 정책에 따르며, 회원은 이를 확인 후 예약해야 합니다.<br/><br/>
+
+    제5조 (후기 작성 및 관리)<br/>
+    1. 회원은 숙박 서비스 이용 후 숙소에 대한 후기(리뷰)를 작성할 수 있습니다.<br/>
+    2. 후기 내용은 객관적이고 사실에 기반해야 하며, 욕설, 비방, 허위 사실 유포 등 타인의 권리를 침해하거나 서비스의 건전한 운영을 저해하는 내용은 삭제될 수 있습니다.<br/><br/>
+
+    제6조 (서비스 이용 제한)<br/>
+    회사는 회원이 본 약관의 의무를 위반하거나 서비스의 정상적인 운영을 방해하는 경우, 서비스 이용을 제한하거나 회원 자격을 상실시킬 수 있습니다.<br/><br/>
+
+    제7조 (면책 조항)<br/>
+    회사는 천재지변, 불가항력 또는 회원의 귀책사유로 인한 서비스 이용의 장애에 대하여는 책임을 지지 않습니다. 또한, 회사는 통신판매중개자로서 호스트와 회원 간의 직접적인 숙박 계약에 대한 일차적인 책임을 지지 않습니다.<br/><br/>
+
+    (본 약관의 상세 내용은 [회사명] 웹사이트에 게시된 전문을 참고하여 주십시오.)
+    ` },
+  { id: 2, label: '(필수) 개인정보 처리방침', required: true, checked: false, content: `
+    제1조 (개인정보의 수집 및 이용 목적)<br/>
+    [회사명] (이하 "회사")는 게스트하우스 예약 서비스 제공을 위해 다음 목적에 따라 최소한의 개인정보를 수집 및 이용합니다.<br/>
+    1. 회원 가입 및 서비스 이용(예약, 결제, 후기 작성 등)<br/>
+    2. 불만 처리 등 고객 상담<br/>
+    3. 마케팅 및 광고 (선택 동의 시)<br/><br/>
+
+    제2조 (수집하는 개인정보 항목)<br/>
+    회사는 원활한 서비스 제공을 위해 다음과 같은 개인정보를 수집할 수 있습니다.<br/>
+    1. **회원 가입 시**: 이메일 주소(ID), 비밀번호, 휴대전화 번호, 관심 테마 정보(선택)<br/>
+    2. **예약 및 결제 시**: 예약자 이름, 숙박 인원, 연락처, 결제 정보(카드사, 카드번호 일부 등)<br/>
+    3. **서비스 이용 시**: IP 주소, 서비스 이용 기록, 접속 로그, 쿠키 등<br/><br/>
+
+    제3조 (개인정보의 보유 및 이용 기간)<br/>
+    회원의 개인정보는 원칙적으로 개인정보 수집 및 이용 목적이 달성되면 지체 없이 파기합니다. 단, 관계 법령의 규정에 의하여 보존할 필요가 있는 경우, 회사는 관계 법령에서 정한 일정한 기간 동안 회원정보를 보관합니다.<br/><br/>
+
+    제4조 (개인정보의 제3자 제공)<br/>
+    회사는 회원의 개인정보를 "제1조 (개인정보의 수집 및 이용 목적)"에서 고지한 범위 내에서만 사용하며, 회원의 사전 동의 없이 동 범위를 초과하여 이용하거나 원칙적으로 외부에 제공하지 않습니다. 다만, 예약 서비스 제공을 위해 필요한 최소한의 정보(예약자 이름, 연락처, 숙박 인원 등)는 해당 호스트에게 제공될 수 있습니다.<br/><br/>
+
+    제5조 (개인정보의 파기 절차 및 방법)<br/>
+    회사는 개인정보 보유기간의 경과, 처리목적 달성 등 개인정보가 불필요하게 되었을 때에는 지체 없이 해당 개인정보를 파기합니다. 전자적 파일 형태의 정보는 기록을 재생할 수 없는 기술적 방법을 사용하며, 종이 문서 형태의 정보는 분쇄기로 분쇄하거나 소각하여 파기합니다.<br/><br/>
+
+    (본 개인정보 처리방침의 상세 내용은 [회사명] 웹사이트에 게시된 전문을 참고하여 주십시오.)
+    ` },
+  { id: 4, label: '(필수) 만 19세 이상 확인', required: true, checked: false, content: `
+    연령 확인 안내 (필수)<br/><br/>
+    본 서비스는 청소년보호법 등 관련 법령에 따라 만 19세 미만 청소년의 숙박 예약 및 이용을 제한하고 있습니다.<br/><br/>
+    이에 회원으로 가입하고 서비스를 이용하기 위해서는 본인이 만 19세 이상임을 확인하고 동의해야 합니다.<br/><br/>
+    만 19세 미만의 자가 허위의 정보로 가입 및 예약을 진행하여 발생하는 모든 문제에 대한 책임은 회원 본인 및 법정대리인에게 있습니다.
+    ` },
+  { id: 3, label: '(선택) 마케팅 정보 수신 동의', required: false, checked: false, content: `
+    마케팅 정보 수신 동의 (선택)<br/><br/>
+
+    [회사명]은(는) 회원님께 더 유용하고 맞춤화된 서비스 및 혜택을 제공하기 위해 마케팅 정보를 발송하고자 합니다.<br/><br/>
+
+    **동의하시는 경우, 아래와 같은 정보를 받아보실 수 있습니다.**<br/>
+    1. 신규 숙소 및 추천 상품 정보: 회원님의 관심사에 맞는 새로운 게스트하우스 또는 특별 할인 상품 소식<br/>
+    2. 이벤트 및 프로모션: 쿠폰, 할인 행사, 시즌별 특별 이벤트 등 회원님께 유리한 혜택 정보<br/>
+    3. 서비스 관련 소식: 서비스 업데이트, 새로운 기능 소개 등 서비스 이용에 도움이 되는 정보<br/><br/>
+
+    수신 채널: 이메일, 문자메시지(SMS/MMS), 앱 푸시 알림<br/><br/>
+
+    본 동의는 선택 사항이며, 동의하지 않으셔도 서비스의 기본 기능 이용에는 어떠한 제한도 없습니다. 마케팅 정보 수신 동의 여부는 "마이페이지 > 개인정보 관리"에서 언제든지 변경하거나 철회할 수 있습니다. 동의를 철회하시는 경우에도 법령에 따른 의무 이행을 위한 정보 및 비마케팅성 정보는 계속 발송될 수 있습니다.<br/><br/>
+
+    (본 마케팅 정보 수신 동의에 대한 상세 내용은 [회사명] 웹사이트에 게시된 전문을 참고하여 주십시오.)
+    ` }
+])
+
+const toggleAll = () => {
+  terms.value.forEach(t => t.checked = allAgreed.value)
+}
+
+const updateAllAgreed = () => {
+  allAgreed.value = terms.value.every(t => t.checked)
+}
+
+const requiredTermsAgreed = computed(() => {
+  return terms.value.filter(t => t.required).every(t => t.checked)
+})
+
+// Terms Modal State
+const showTermsModal = ref(false)
+const termsModalTitle = ref('')
+const termsModalContent = ref('')
+
+const openTermsModal = (term) => {
+  termsModalTitle.value = term.label
+  termsModalContent.value = term.content
+  showTermsModal.value = true
+}
+
+const closeTermsModal = () => {
+  showTermsModal.value = false
+}
+
+// Step 2: Theme Selection
+const themes = ref([
+  { id: 1, label: '액티비티', selected: false },
+  { id: 2, label: '맛집', selected: false },
+  { id: 3, label: '카페', selected: false },
+  { id: 4, label: '문화/예술', selected: false },
+  { id: 5, label: '자연/힐링', selected: false },
+  { id: 6, label: '쇼핑', selected: false },
+  { id: 7, label: '역사/관광', selected: false },
+  { id: 8, label: '엔터테인먼트', selected: false },
+  { id: 9, label: '스포츠', selected: false },
+  { id: 10, label: '음악', selected: false },
+  { id: 11, label: '반려동물', selected: false },
+  { id: 12, label: '기타', selected: false }
+])
+
+const toggleTheme = (theme) => {
+  theme.selected = !theme.selected
+}
+
+// Modal
+const showModal = ref(false)
+const modalMessage = ref('')
+const modalType = ref('info')
+const modalCallback = ref(null)
+
+const openModal = (message, type = 'info', callback = null) => {
+  modalMessage.value = message
+  modalType.value = type
+  modalCallback.value = callback
+  showModal.value = true
+}
+
+const closeModal = () => {
+  showModal.value = false
+  if (modalCallback.value) {
+    modalCallback.value()
+    modalCallback.value = null
+  }
+}
+
+// Navigation
+const goBack = () => {
+  if (currentStep.value > 1) {
+    currentStep.value--
+  } else {
+    router.push('/login')
+  }
+}
+
+const goNext = () => {
+  if (currentStep.value === 1) {
+    if (requiredTermsAgreed.value) {
+      currentStep.value = 2
+    } else {
+      openModal('필수 약관에 동의해주세요.', 'error')
+    }
+  }
+}
+
+const handleComplete = async () => {
+  isLoading.value = true
+
+  try {
+    // 선택된 테마 ID 추출
+    const selectedThemeIds = themes.value
+      .filter(theme => theme.selected)
+      .map(theme => theme.id)
+
+    // 마케팅 동의 확인
+    const marketingTerm = terms.value.find(t => t.id === 3)
+    const marketingAgreed = marketingTerm ? marketingTerm.checked : false
+
+    // 소셜 회원가입 데이터 생성
+    const signupData = {
+      termsAgreed: true,
+      themeIds: selectedThemeIds.length > 0 ? selectedThemeIds : null,
+      marketingAgreed: marketingAgreed
+    }
+
+    console.log('소셜 회원가입 데이터:', signupData)
+
+    // API 호출
+    const response = await completeSocialSignup(signupData)
+
+    console.log('소셜 회원가입 응답:', response)
+
+    if (response.ok && response.data) {
+      // 회원가입 성공
+      console.log('소셜 회원가입 완료!')
+      openModal('회원가입이 완료되었습니다!', 'success', () => router.push('/'))
+    } else {
+      // 회원가입 실패
+      console.error('소셜 회원가입 실패:', response)
+      openModal('회원가입에 실패했습니다.\n잠시 후 다시 시도해주세요.', 'error')
+    }
+  } catch (error) {
+    console.error('소셜 회원가입 에러:', error)
+    openModal('회원가입 중 오류가 발생했습니다.', 'error')
+  } finally {
+    isLoading.value = false
+  }
+}
+
+const handleSkip = async () => {
+  isLoading.value = true
+
+  try {
+    // 테마 선택 없이 회원가입
+    const marketingTerm = terms.value.find(t => t.id === 3)
+    const marketingAgreed = marketingTerm ? marketingTerm.checked : false
+
+    const signupData = {
+      termsAgreed: true,
+      themeIds: null,
+      marketingAgreed: marketingAgreed
+    }
+
+    console.log('소셜 회원가입 데이터 (건너뛰기):', signupData)
+
+    const response = await completeSocialSignup(signupData)
+
+    console.log('소셜 회원가입 응답 (건너뛰기):', response)
+
+    if (response.ok && response.data) {
+      console.log('소셜 회원가입 완료 (건너뛰기)!')
+      openModal('회원가입이 완료되었습니다!', 'success', () => router.push('/'))
+    } else {
+      console.error('소셜 회원가입 실패 (건너뛰기):', response)
+      openModal('회원가입에 실패했습니다.\n잠시 후 다시 시도해주세요.', 'error')
+    }
+  } catch (error) {
+    console.error('소셜 회원가입 에러:', error)
+    openModal('회원가입 중 오류가 발생했습니다.', 'error')
+  } finally {
+    isLoading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="register-page">
+    <div class="register-container">
+      <!-- Header -->
+      <div class="page-header">
+        <button class="back-btn" @click="goBack">←</button>
+        <h1>{{ currentStep === 1 ? '약관 동의' : '관심 테마 선택' }}</h1>
+      </div>
+
+      <!-- Progress Steps -->
+      <div class="progress-steps">
+        <div class="step" :class="{ active: currentStep >= 1, done: currentStep > 1 }">
+          <span v-if="currentStep > 1">✓</span>
+          <span v-else>1</span>
+        </div>
+        <div class="step-line" :class="{ active: currentStep >= 2 }"></div>
+        <div class="step" :class="{ active: currentStep >= 2 }">
+          <span>2</span>
+        </div>
+      </div>
+      <div class="step-labels">
+        <span :class="{ active: currentStep === 1 }">약관동의</span>
+        <span :class="{ active: currentStep === 2 }">테마선택</span>
+      </div>
+
+      <!-- Step 1: Terms -->
+      <template v-if="currentStep === 1">
+        <div class="terms-section">
+          <label class="all-agree">
+            <input type="checkbox" v-model="allAgreed" @change="toggleAll" />
+            <span>전체 동의</span>
+          </label>
+          <hr class="divider" />
+
+          <div class="term-list">
+            <label v-for="term in terms" :key="term.id" class="term-row">
+              <input type="checkbox" v-model="term.checked" @change="updateAllAgreed" />
+              <span>{{ term.label }}</span>
+              <button type="button" class="view-term-btn" @click.stop="openTermsModal(term)">보기</button>
+            </label>
+          </div>
+        </div>
+
+        <button class="next-btn" :disabled="!requiredTermsAgreed" @click="goNext">다음</button>
+      </template>
+
+      <!-- Step 2: Theme Selection -->
+      <template v-if="currentStep === 2">
+        <div class="theme-section">
+          <p class="theme-desc">관심있는 테마를 선택하시면 맞춤형 추천을 받으실 수 있습니다.<br/>(복수 선택 가능)</p>
+
+          <div class="theme-grid">
+            <button
+              v-for="theme in themes"
+              :key="theme.id"
+              class="theme-btn"
+              :class="{ selected: theme.selected }"
+              @click="toggleTheme(theme)"
+            >
+              <span class="theme-checkbox">{{ theme.selected ? '☑' : '☐' }}</span>
+              <span>{{ theme.label }}</span>
+            </button>
+          </div>
+        </div>
+
+        <div class="final-actions">
+          <button class="complete-btn" @click="handleComplete" :disabled="isLoading">
+            {{ isLoading ? '처리 중...' : '완료' }}
+          </button>
+          <button class="skip-btn" @click="handleSkip" :disabled="isLoading">
+            {{ isLoading ? '처리 중...' : '건너뛰기' }}
+          </button>
+        </div>
+      </template>
+    </div>
+
+    <!-- Modal -->
+    <div v-if="showModal" class="modal-overlay" @click.self="closeModal">
+      <div class="modal-content">
+        <div class="modal-icon" :class="modalType">
+          <span v-if="modalType === 'success'">✓</span>
+          <span v-else-if="modalType === 'error'">!</span>
+          <span v-else>i</span>
+        </div>
+        <p class="modal-message">{{ modalMessage }}</p>
+        <button class="modal-btn" @click="closeModal">확인</button>
+      </div>
+    </div>
+
+    <!-- Terms Modal -->
+    <div v-if="showTermsModal" class="modal-overlay" @click.self="closeTermsModal">
+      <div class="modal-content large">
+        <h2>{{ termsModalTitle }}</h2>
+        <div class="terms-content-scroll">
+          <div v-html="termsModalContent"></div>
+        </div>
+        <button class="modal-btn" @click="closeTermsModal">닫기</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.register-page {
+  min-height: 100vh;
+  background: #f9fafb;
+  padding: 1rem;
+}
+
+.register-container {
+  background: white;
+  max-width: 500px;
+  margin: 0 auto;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.05);
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.back-btn {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.page-header h1 {
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+/* Progress Steps */
+.progress-steps {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 0.5rem;
+}
+
+.step {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #eee;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 0.9rem;
+  color: #888;
+}
+
+.step.active {
+  background: #333;
+  color: white;
+}
+
+.step.done {
+  background: var(--primary);
+  color: #004d40;
+}
+
+.step-line {
+  width: 50px;
+  height: 2px;
+  background: #eee;
+}
+
+.step-line.active {
+  background: #333;
+}
+
+.step-labels {
+  display: flex;
+  justify-content: space-around;
+  max-width: 200px;
+  margin: 0 auto 2rem;
+  font-size: 0.8rem;
+  color: #888;
+}
+
+.step-labels span.active {
+  color: #2563eb;
+  font-weight: 600;
+}
+
+/* Terms */
+.terms-section {
+  margin-bottom: 2rem;
+}
+
+.all-agree {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.5rem 0;
+}
+
+.all-agree input {
+  width: 20px;
+  height: 20px;
+  accent-color: var(--primary);
+}
+
+.divider {
+  border: 0;
+  border-top: 2px solid #333;
+  margin: 1rem 0;
+}
+
+.term-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.term-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+}
+
+.term-row input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--primary);
+}
+
+.term-row span {
+  flex: 1;
+  font-size: 0.95rem;
+}
+
+.view-term-btn {
+  background: none;
+  border: none;
+  color: #00796b;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  transition: background 0.2s;
+}
+
+.view-term-btn:hover {
+  background: #f0f0f0;
+}
+
+/* Theme Selection */
+.theme-section {
+  margin-bottom: 2rem;
+}
+
+.theme-desc {
+  font-size: 0.9rem;
+  color: #2563eb;
+  margin-bottom: 1.5rem;
+  line-height: 1.5;
+}
+
+.theme-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.theme-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1.5rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 12px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.theme-btn.selected {
+  border-color: var(--primary);
+}
+
+.theme-checkbox {
+  font-size: 1.5rem;
+  color: #ccc;
+}
+
+.theme-btn.selected .theme-checkbox {
+  color: #004d40;
+}
+
+/* Buttons */
+.next-btn {
+  width: 100%;
+  padding: 1rem;
+  background: var(--primary);
+  color: #004d40;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.next-btn:disabled {
+  background: #e5e7eb;
+  color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.final-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.complete-btn {
+  width: 100%;
+  padding: 1rem;
+  background: #333;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.complete-btn:disabled {
+  background: #ccc;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.skip-btn {
+  width: 100%;
+  padding: 1rem;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.skip-btn:disabled {
+  background: #f5f5f5;
+  color: #9ca3af;
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: white;
+  border-radius: 16px;
+  padding: 2rem;
+  max-width: 320px;
+  width: 90%;
+  text-align: center;
+}
+
+.modal-icon {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 1rem;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.modal-icon.success {
+  background: var(--primary);
+  color: #004d40;
+}
+
+.modal-icon.error {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.modal-icon.info {
+  background: #e0f2fe;
+  color: #0284c7;
+}
+
+.modal-message {
+  font-size: 1rem;
+  color: #333;
+  margin-bottom: 1.5rem;
+  line-height: 1.5;
+}
+
+.modal-content.large {
+  max-width: 600px;
+  width: 95%;
+  padding: 2.5rem;
+}
+
+.terms-content-scroll {
+  max-height: 400px;
+  overflow-y: auto;
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  text-align: left;
+  line-height: 1.6;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.modal-content h2 {
+  font-size: 1.3rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+  color: #333;
+}
+
+.modal-btn {
+  width: 100%;
+  padding: 0.8rem;
+  background: var(--primary);
+  color: #004d40;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+</style>

--- a/frontend/src/views/home/HomeView.vue
+++ b/frontend/src/views/home/HomeView.vue
@@ -37,6 +37,11 @@ const goToThemeList = (themeId) => {
 }
 
 const loadWishlist = async () => {
+  // 로그인하지 않은 경우 위시리스트를 로드하지 않음
+  if (!isAuthenticated()) {
+    return
+  }
+
   try {
     const res = await fetchWishlistIds()
     if (res.status === 200 && Array.isArray(res.data)) {

--- a/frontend/src/views/home/HomeView.vue.backup_header
+++ b/frontend/src/views/home/HomeView.vue.backup_header
@@ -1,4 +1,0 @@
-﻿<script setup>
-import { onMounted, ref } from 'vue'
-import GuesthouseCard from '../../components/GuesthouseCard.vue'
-import { useRouter } from 'vue-router'


### PR DESCRIPTION
 💡 PR 제목
  > feat: 인증 로직 개선 및 버그 수정

  ---

  🔗 관련 이슈
   - Refs: #146 

  ---

  📌 작업 내용 요약
   - [x] 소셜 로그인 회원가입 흐름 변경: 소셜 로그인 시, 자사 약관 동의 및 테마 선택 단계를 거치도록 변경 (UI/UX 및 백엔드 로직 연동)   
   - [x] 로그인 상태 유지 정책 명확화 및 서버 재시작과 무관한 안정적인 인증 상태 유지
   - [x] 리프레시 토큰 만료 시간 조정 (기존 7일에서 30분으로 변경)
   - [x] 로컬 로그인 API 동작 검증을 위한 통합 테스트 코드 추가

  ---

  🧱 변경 범위 (Scope)
  Backend
   - [x] API 추가/수정 (소셜 로그인 회원가입 관련)
   - [ ] Validation/예외처리
   - [x] 인증/인가 
   - [ ] DB 스키마/쿼리
   - [x] 기타: 테스트 코드 추가

  Frontend
   - [x] UI/라우팅 (소셜 로그인 흐름 변경에 따른 화면 및 라우팅 조정)
   - [ ] 상태관리/비동기 로직
   - [ ] 입력값/검증
   - [ ] 기타:

  ---

  🧪 테스트 내역
  Backend
   - [ ] 로컬에서 애플리케이션 실행 확인
   - [x] 단위 테스트 통과
   - [x] API 수동 테스트 (Postman / Swagger 등)

  Frontend
   - [x] npm run dev 로컬 실행 확인 (변경된 소셜 로그인 흐름 수동 테스트)
   - [x] 주요 화면/기능 수동 테스트 (변경된 소셜 로그인 흐름, 로그인/로그아웃 등)

  테스트 상세(필수)
  > 테스트한 API/페이지/케이스를 간단히 적어주세요.
   - 소셜 로그인: 변경된 소셜 로그인 회원가입 흐름(약관 동의 -> 테마 선택)에 따라 신규 회원가입 및 로그인 절차 수동 테스트 완료
   - 로컬 로그인: AuthControllerTest 테스트 슈트를 통해 로그인 성공/실패(잘못된 비밀번호, 미가입자 등) 케이스 검증
   - 로그아웃/세션: 리프레시 토큰 만료(30분) 후 재로그인이 필요한지 확인

  ---

  ---

  ⚠️ 영향도 / 리스크 / 롤백
  > 리뷰어가 “머지해도 되는지” 판단하기 위한 섹션입니다.
   - 영향도:
       - 소셜 로그인 회원가입 사용자 경험 흐름이 변경됩니다. 기존 users 테이블의 social_signup_completed 필드와 user_theme 테이블에  영향을 줄 수 있습니다.
       - 
       - 사용자의 최대 로그인 유지 시간 30분으로 단축


