### PR TITLE
feat : KaKao 소셜 기능 추가

### DIFF
--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/service/CustomOAuth2UserService.java
@@ -40,6 +40,8 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             oAuth2UserInfo = new NaverOAuth2UserInfo(oAuth2User.getAttributes());
         } else if ("google".equals(registrationId)) {
             oAuth2UserInfo = new GoogleOAuth2UserInfo(oAuth2User.getAttributes());
+        } else if ("kakao".equals(registrationId)) {
+            oAuth2UserInfo = new KakaoOAuth2UserInfo(oAuth2User.getAttributes());
         } else {
             throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다: " + registrationId);
         }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/service/KakaoOAuth2UserInfo.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/service/KakaoOAuth2UserInfo.java
@@ -1,0 +1,65 @@
+package com.ssg9th2team.geharbang.global.oauth.service;
+
+import com.ssg9th2team.geharbang.global.oauth.service.OAuth2UserInfo;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+    private final Map<String, Object> kakaoAccount;
+    private final Map<String, Object> profile;
+
+    @SuppressWarnings("unchecked")
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.profile = (Map<String, Object>) kakaoAccount.get("profile");
+    }
+
+    @Override
+    public String getProviderId() {
+        // 카카오 응답의 최상위 'id' 값을 String으로 변환하여 반환
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getEmail() {
+        // 'kakao_account' 맵에서 'email' 정보를 가져옴
+        return (String) kakaoAccount.get("email");
+    }
+
+    @Override
+    public String getName() {
+        // 'profile' 맵에서 'nickname' 정보를 가져옴
+        if (profile == null) {
+            return null;
+        }
+        return (String) profile.get("nickname");
+    }
+
+    @Override
+    public String getGender() {
+        // 카카오 API에서 성별 정보는 'gender' 필드로 제공됨
+        // 단, 사용자가 동의 항목에서 '성별'을 선택해야만 받을 수 있음
+        if (kakaoAccount == null) {
+            return null;
+        }
+        return (String) kakaoAccount.get("gender");
+    }
+
+    @Override
+    public String getMobile() {
+        // 카카오 API에서 전화번호 정보는 'phone_number' 필드로 제공됨
+        // 단, 사용자가 동의 항목에서 '카카오계정(전화번호)'을 선택해야만 받을 수 있음
+        if (kakaoAccount == null) {
+            return null;
+        }
+        return (String) kakaoAccount.get("phone_number");
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -110,3 +110,15 @@ oauth2.signup-redirect-uri=http://localhost:5173/social-signup
 
 # Flyway Validation 비활성화 (개발 중 체크섬 불일치 해결용)
 spring.flyway.validate-on-migrate=false
+
+# Kakao OAuth2 Login (Provider Settings)
+spring.security.oauth2.client.registration.kakao.client-name=Kakao
+spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao
+spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.kakao.client-authentication-method=client_secret_post
+spring.security.oauth2.client.registration.kakao.scope=profile_nickname,account_email
+
+spring.security.oauth2.client.provider.kakao.authorization-uri=https://kauth.kakao.com/oauth/authorize
+spring.security.oauth2.client.provider.kakao.token-uri=https://kauth.kakao.com/oauth/token
+spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.com/v2/user/me
+spring.security.oauth2.client.provider.kakao.user-name-attribute=id

--- a/frontend/src/views/LoginView/LoginView.vue
+++ b/frontend/src/views/LoginView/LoginView.vue
@@ -90,8 +90,8 @@ const socialLogin = (provider) => {
     Naver: `${baseUrl}/oauth2/authorization/naver` // Naver OAuth2 (구현 완료)
   }
 
-  if (provider === 'Naver' || provider === 'Google') {
-    // 네이버 또는 구글 로그인은 바로 리다이렉트
+  if (provider === 'Naver' || provider === 'Google' || provider === 'Kakao') {
+    // 네이버, 구글, 카카오 로그인은 바로 리다이렉트
     window.location.href = urls[provider]
   } else {
     // 다른 소셜 로그인은 아직 구현되지 않음


### PR DESCRIPTION
💡 PR 제목
  > feat: [KHG] 카카오 소셜 로그인 기능 구현

  ---

  🔗 관련 이슈
  > 진행 중이면 Refs #186 
   - Closes: # (여기에 관련 이슈 번호를 넣어주세요)

  ---

  📌 작업 내용 요약
   - 카카오 소셜 로그인 기능 추가
   - 백엔드: 카카오 로그인 관련 OAuth2 설정 및 사용자 정보 처리 로직 구현
   - 프론트엔드: '카카오로 시작하기' 버튼 기능 활성화

  ---

  🧱 변경 범위 (Scope)
  Backend
   - [x] API 추가/수정 (OAuth2 Redirect Endpoint)
   - [ ] Validation/예외처리
   - [x] 인증/인가 (신규 소셜 프로바이더 추가)
   - [ ] DB 스키마/쿼리
   - [ ] 기타:

  Frontend
   - [x] UI/라우팅 (로그인 버튼 클릭 시 카카오 인증 페이지로 리다이렉션)
   - [x] 상태관리/비동기 로직 (socialLogin 함수 수정)
   - [ ] 입력값/검증
   - [ ] 기타:

  ---

  🧪 테스트 내역
  Backend
   - [x] 로컬에서 애플리케이션 실행 확인
   - [ ] 단위 테스트 통과
   - [x] API 수동 테스트 (Postman / Swagger 등)

  Frontend
   - [x] npm run dev 로컬 실행 확인
   - [x] 주요 화면/기능 수동 테스트

  테스트 상세(필수)
  > 테스트한 API/페이지/케이스를 간단히 적어주세요.
   - 프론트엔드 로그인 페이지에서 '카카오로 시작하기' 버튼 클릭
   - 카카오 계정으로 로그인 후, 백엔드를 거쳐 프론트엔드
     페이지(http://localhost:5173/oauth2/redirect)로 정상 이동하는지 확인
   - 신규 사용자일 경우: DB의 user 및 user_social 테이블에 새 정보가 생성되는지 확인      
   - 기존 사용자일 경우: 새 계정 생성 없이 기존 계정으로 로그인되는지 확인

  ---

  🖼️ 화면 캡처 / 시연 영상 (Frontend 변경 시 권장)
   - before: '카카오로 시작하기' 버튼 클릭 시 "준비 중입니다" 모달 표시
   - after: '카카오로 시작하기' 버튼 클릭 시 카카오 로그인 페이지로 정상 이동

  ---

  ⚠️ 영향도 / 리스크 / 롤백
  > 리뷰어가 “머지해도 되는지” 판단하기 위한 섹션입니다.
   - 영향도: 기존 네이버, 구글 소셜 로그인 및 일반 로그인 기능에 영향 없음. 신규 인증     
     방식(카카오) 추가.
   - 리스크: application-secret.properties에 카카오 REST API 키(client-id) 설정이
     누락되거나 잘못된 경우, 카카오 로그인 시 서버 오류가 발생합니다.
   - 롤백 방법: 해당 PR에 해당하는 커밋을 revert하여 롤백합니다.
