### PR TITLE
feat: 사용자 프로필 화면 UI 개선 및 회원 탈퇴 오류 해결 

### DIFF
--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/UserResponse.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/dto/UserResponse.java
@@ -1,7 +1,6 @@
 package com.ssg9th2team.geharbang.domain.auth.dto;
 
 import com.ssg9th2team.geharbang.domain.auth.entity.User;
-import com.ssg9th2team.geharbang.domain.auth.entity.UserRole;
 import com.ssg9th2team.geharbang.domain.user.entity.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,7 +21,6 @@ public class UserResponse {
     private String email;
     private String phone;
     private Gender gender;
-    private UserRole role;
     private Boolean marketingAgreed;
     private Boolean hostApproved;
     private LocalDateTime createdAt;
@@ -36,7 +34,6 @@ public class UserResponse {
                 .email(user.getEmail())
                 .phone(user.getPhone())
                 .gender(user.getGender())
-                .role(user.getRole())
                 .marketingAgreed(user.getMarketingAgreed())
                 .hostApproved(user.getHostApproved())
                 .createdAt(user.getCreatedAt())

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/User.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/auth/entity/User.java
@@ -110,10 +110,11 @@ public class User {
         this.phone = phone;
     }
 
-    // 닉네임, 전화번호만 업데이트
-    public void updateProfile(String nickname, String phone) {
+    // 닉네임, 전화번호, 성별 업데이트
+    public void updateProfile(String nickname, String phone, Gender gender) {
         this.nickname = nickname;
         this.phone = phone;
+        this.gender = gender;
     }
 
     // 역할 변경 (예: USER -> HOST)

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/payment/repository/jpa/PaymentRefundJpaRepository.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/payment/repository/jpa/PaymentRefundJpaRepository.java
@@ -2,6 +2,7 @@ package com.ssg9th2team.geharbang.domain.payment.repository.jpa;
 
 import com.ssg9th2team.geharbang.domain.payment.entity.PaymentRefund;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,6 +15,7 @@ public interface PaymentRefundJpaRepository extends JpaRepository<PaymentRefund,
 
     Optional<PaymentRefund> findByPgRefundKey(String pgRefundKey);
 
+    @Modifying
     void deleteByPaymentIdIn(List<Long> paymentIds);
 
     void deleteByPaymentId(Long paymentId);

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/report/repository/jpa/ReviewReportJpaRepository.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/report/repository/jpa/ReviewReportJpaRepository.java
@@ -3,8 +3,15 @@ package com.ssg9th2team.geharbang.domain.report.repository.jpa;
 import com.ssg9th2team.geharbang.domain.report.entity.ReviewReport;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewReportJpaRepository extends JpaRepository<ReviewReport, Long>, JpaSpecificationExecutor<ReviewReport> {
+
+    @Modifying
+    @Query("DELETE FROM ReviewReport rr WHERE rr.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/reservation/repository/jpa/ReservationJpaRepository.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/reservation/repository/jpa/ReservationJpaRepository.java
@@ -21,6 +21,12 @@ public interface ReservationJpaRepository
         @Query("SELECT r FROM Reservation r WHERE r.userId = :userId AND r.isDeleted = false")
         List<Reservation> findByUserId(@Param("userId") Long userId);
 
+        // 활성 예약 조회 (취소되지 않은 예약, 임시 예약 제외)
+        // 예약 상태: 0(임시-결제대기), 1(요청), 2(확정), 3(체크인완료), 9(취소)
+        // 임시(0) 상태는 결제 대기 중이며 30분 후 자동 삭제되므로 활성 예약에서 제외
+        @Query("SELECT r FROM Reservation r WHERE r.userId = :userId AND r.isDeleted = false AND r.reservationStatus != 9 AND r.reservationStatus != 0")
+        List<Reservation> findActiveReservationsByUserId(@Param("userId") Long userId);
+
         @Query("SELECT r FROM Reservation r WHERE r.accommodationsId = :accommodationsId AND r.isDeleted = false")
         List<Reservation> findByAccommodationsId(@Param("accommodationsId") Long accommodationsId);
 
@@ -82,9 +88,13 @@ public interface ReservationJpaRepository
                         "where r.createdAt >= :start and r.createdAt < :end")
         long countDistinctHost(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
+<<<<<<< Updated upstream
         /**
          * 유저의 결제 완료된 예약 수 카운트 (reservationStatus = 2: 확정)
          */
         long countByUserIdAndReservationStatus(Long userId, Integer reservationStatus);
 
+=======
+        List<Reservation> findAllByUserId(Long userId);
+>>>>>>> Stashed changes
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/review/repository/jpa/ReviewJpaRepository.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/review/repository/jpa/ReviewJpaRepository.java
@@ -2,6 +2,9 @@ package com.ssg9th2team.geharbang.domain.review.repository.jpa;
 
 import com.ssg9th2team.geharbang.domain.review.entity.ReviewEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -19,8 +22,14 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewEntity, Long> {
     // 이미 리뷰 작성했는지 확인
     boolean existsByUserIdAndAccommodationsIdAndIsDeletedFalse(Long userId, Long accommodationsId);
 
+<<<<<<< Updated upstream
     // 유저의 리뷰 개수 카운트 (쿠폰 발급용)
     long countByUserIdAndIsDeletedFalse(Long userId);
+=======
+    @Modifying
+    @Query("DELETE FROM ReviewEntity r WHERE r.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
+>>>>>>> Stashed changes
 
 }
 

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/dto/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/dto/UpdateProfileRequest.java
@@ -1,6 +1,8 @@
 package com.ssg9th2team.geharbang.domain.user.dto;
 
+import com.ssg9th2team.geharbang.domain.user.entity.Gender;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -19,4 +21,7 @@ public class UpdateProfileRequest {
     @NotBlank(message = "전화번호는 필수입니다.")
     @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호 형식이 올바르지 않습니다. (010-1234-5678)")
     private String phone;
+
+    @NotNull(message = "성별은 필수입니다.")
+    private Gender gender;
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/user/service/UserServiceImpl.java
@@ -4,15 +4,24 @@ import com.ssg9th2team.geharbang.domain.auth.entity.User;
 import com.ssg9th2team.geharbang.domain.auth.entity.UserSocial;
 import com.ssg9th2team.geharbang.domain.auth.repository.UserRepository;
 import com.ssg9th2team.geharbang.domain.auth.repository.UserSocialRepository;
+import com.ssg9th2team.geharbang.domain.payment.entity.Payment;
+import com.ssg9th2team.geharbang.domain.payment.entity.PaymentRefund;
+import com.ssg9th2team.geharbang.domain.payment.repository.jpa.PaymentJpaRepository;
+import com.ssg9th2team.geharbang.domain.payment.repository.jpa.PaymentRefundJpaRepository;
+import com.ssg9th2team.geharbang.domain.report.repository.jpa.ReviewReportJpaRepository;
 import com.ssg9th2team.geharbang.domain.reservation.entity.Reservation;
 import com.ssg9th2team.geharbang.domain.reservation.repository.jpa.ReservationJpaRepository;
+import com.ssg9th2team.geharbang.domain.review.repository.jpa.ReviewJpaRepository;
 import com.ssg9th2team.geharbang.domain.user.dto.DeleteAccountRequest;
 import com.ssg9th2team.geharbang.domain.user.dto.UpdateProfileRequest;
+import com.ssg9th2team.geharbang.domain.wishlist.repository.jpa.WishlistJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -22,33 +31,98 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final ReservationJpaRepository reservationRepository;
     private final UserSocialRepository userSocialRepository;
+    private final PaymentJpaRepository paymentJpaRepository;
+    private final PaymentRefundJpaRepository paymentRefundJpaRepository;
+    private final ReviewReportJpaRepository reviewReportJpaRepository;
+    private final ReviewJpaRepository reviewJpaRepository;
+    private final WishlistJpaRepository wishlistJpaRepository;
 
     @Override
     @Transactional
     public void deleteUser(String email, DeleteAccountRequest deleteAccountRequest) {
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        log.info("회원 탈퇴 시도: email={}", email);
 
+        try {
+            User user = userRepository.findByEmail(email)
+                    .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+            Long userId = user.getId();
+            log.info("사용자 조회 성공: userId={}, email={}", userId, email);
 
-        List<Reservation> reservations = reservationRepository.findByUserId(user.getId());
-        boolean hasActiveReservations = reservations.stream()
-                .anyMatch(r -> r.getReservationStatus() != 3); // 3: Cancelled
+            // 1. 활성 예약 확인 (진행중인 예약이 있으면 탈퇴 불가)
+            List<Reservation> activeReservations = reservationRepository.findActiveReservationsByUserId(userId);
+            if (!activeReservations.isEmpty()) {
+                log.warn("사용자 {} 탈퇴 실패 - 활성 예약 {}건 존재", email, activeReservations.size());
+                throw new IllegalStateException("진행 중인 예약이 있어 탈퇴할 수 없습니다.");
+            }
 
-        if (hasActiveReservations) {
-            throw new IllegalStateException("진행 중이거나 완료된 예약이 있어 탈퇴할 수 없습니다. 모든 예약을 취소한 후 다시 시도해주세요.");
+            // --- 연관 데이터 삭제 시작 ---
+
+            // 2. 사용자의 모든 예약 조회
+            List<Reservation> allReservations = reservationRepository.findAllByUserId(userId);
+            if (!allReservations.isEmpty()) {
+                List<Long> reservationIds = allReservations.stream()
+                        .map(Reservation::getId)
+                        .collect(Collectors.toList());
+
+                // 3. 예약에 연결된 결제 기록 조회
+                List<Payment> payments = paymentJpaRepository.findByReservationIdIn(reservationIds);
+                if (!payments.isEmpty()) {
+                    List<Long> paymentIds = payments.stream()
+                            .map(Payment::getId)
+                            .collect(Collectors.toList());
+
+                    // 4. 결제에 연결된 환불 기록 조회 및 삭제
+                    List<PaymentRefund> refunds = paymentIds.stream()
+                            .flatMap(paymentId -> paymentRefundJpaRepository.findByPaymentId(paymentId).stream())
+                            .collect(Collectors.toList());
+
+                    if (!refunds.isEmpty()) {
+                        paymentRefundJpaRepository.deleteAllInBatch(refunds);
+                        log.info("사용자 {}의 환불 기록 {}건 삭제 완료", email, refunds.size());
+                    }
+
+                    // 5. 결제 기록 삭제
+                    paymentJpaRepository.deleteAllInBatch(payments);
+                    log.info("사용자 {}의 결제 기록 {}건 삭제 완료", email, payments.size());
+                }
+
+                // 6. 예약 기록 삭제
+                reservationRepository.deleteAllInBatch(allReservations);
+                log.info("사용자 {}의 예약 기록 삭제 완료", email);
+            }
+
+            // 7. 리뷰 신고 기록 삭제
+            reviewReportJpaRepository.deleteAllByUserId(userId);
+            log.info("사용자 {}의 리뷰 신고 기록 삭제 완료", email);
+
+            // 8. 리뷰 기록 삭제
+            reviewJpaRepository.deleteAllByUserId(userId);
+            log.info("사용자 {}의 리뷰 기록 삭제 완료", email);
+
+            // 9. 위시리스트 삭제
+            wishlistJpaRepository.deleteAllByUserId(userId);
+            log.info("사용자 {}의 위시리스트 삭제 완료", email);
+
+            // 10. 소셜 로그인 정보 삭제
+            List<UserSocial> userSocials = userSocialRepository.findByUser(user);
+            if (!userSocials.isEmpty()) {
+                userSocialRepository.deleteAll(userSocials);
+                log.info("사용자 {}의 연결된 소셜 로그인 정보 {}개 삭제", email, userSocials.size());
+            }
+
+            // 11. 최종 사용자 삭제
+            log.info("사용자 {} 탈퇴 처리 시작. 사유: {}, 기타: {}", email, deleteAccountRequest.getReasons(),
+                    deleteAccountRequest.getOtherReason());
+            userRepository.delete(user);
+            log.info("사용자 {} 탈퇴 성공", email);
+
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            log.error("회원 탈퇴 실패 (검증 오류): email={}, error={}", email, e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            log.error("회원 탈퇴 중 예상치 못한 오류 발생: email={}", email, e);
+            throw new RuntimeException("회원 탈퇴 처리 중 오류가 발생했습니다.", e);
         }
-
-        // 연결된 소셜 로그인 정보 삭제
-        List<UserSocial> userSocials = userSocialRepository.findByUser(user);
-        if (!userSocials.isEmpty()) {
-            userSocialRepository.deleteAll(userSocials);
-            log.info("사용자 {}의 연결된 소셜 로그인 정보 {}개 삭제", email, userSocials.size());
-        }
-
-        log.info("사용자 {} 탈퇴. 사유: {}, 기타: {}", email, deleteAccountRequest.getReasons(),
-                deleteAccountRequest.getOtherReason());
-
-        userRepository.delete(user);
     }
 
     @Override
@@ -67,6 +141,6 @@ public class UserServiceImpl implements UserService {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
-        user.updateProfile(request.getNickname(), request.getPhone());
+        user.updateProfile(request.getNickname(), request.getPhone(), request.getGender());
     }
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/domain/wishlist/repository/jpa/WishlistJpaRepository.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/domain/wishlist/repository/jpa/WishlistJpaRepository.java
@@ -18,4 +18,8 @@ public interface WishlistJpaRepository extends JpaRepository<Wishlist, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM Wishlist w WHERE w.userId = :userId AND w.accommodationsId = :accommodationsId")
     void deleteByUserIdAndAccommodationsId(@Param("userId") Long userId, @Param("accommodationsId") Long accommodationsId);
+
+    @Modifying
+    @Query("DELETE FROM Wishlist w WHERE w.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/error/GlobalExceptionHandler.java
@@ -25,6 +25,13 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.CONFLICT); // 409 에러
     }
 
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException ex) {
+        log.error("RuntimeException: {}", ex.getMessage(), ex);
+        ErrorResponse response = new ErrorResponse(ex.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception ex) {
         log.error("Unhandled Exception: ", ex);

--- a/frontend/src/views/mypage/ProfileView.vue
+++ b/frontend/src/views/mypage/ProfileView.vue
@@ -9,7 +9,6 @@ const user = ref({
   email: '',
   phone: '',
   nickname: '',
-  role: '',
   gender: ''
 })
 const editableUser = ref({})
@@ -48,7 +47,6 @@ const loadUserData = async () => {
         email: response.data.email || '',
         phone: response.data.phone || '정보 없음',
         nickname: response.data.nickname || '',
-        role: response.data.role || 'USER',
         gender: response.data.gender || ''
       }
     } else {
@@ -110,11 +108,13 @@ const handleProfileUpdate = async () => {
     const response = await updateUserProfile({
       nickname: editableUser.value.nickname,
       phone: editableUser.value.phone,
+      gender: editableUser.value.gender,
     })
 
     if (response.ok) {
       user.value.nickname = editableUser.value.nickname
       user.value.phone = editableUser.value.phone
+      user.value.gender = editableUser.value.gender
       updateMessage.value = '변경에 성공했습니다.'
       updateMessageType.value = 'success'
       // 2초 후 편집 모드 종료
@@ -134,12 +134,6 @@ const handleProfileUpdate = async () => {
     updateMessage.value = '프로필 업데이트 중 오류가 발생했습니다.'
     updateMessageType.value = 'error'
   }
-}
-
-const getRoleText = (role) => {
-  if (role === 'HOST') return '호스트'
-  if (role === 'USER') return '일반 사용자'
-  return '일반 사용자'
 }
 
 const getGenderText = (gender) => {
@@ -162,261 +156,616 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="profile-page container">
-    <div class="sub-header">
-      <button class="back-btn" @click="goBack">‹</button>
-      <h3>프로필 정보</h3>
-      <div class="header-buttons">
-        <template v-if="!isEditMode">
-          <button class="edit-btn" @click="startEdit">✎</button>
-        </template>
-        <template v-else>
-          <button class="cancel-btn" @click="cancelEdit">취소</button>
-          <button class="save-btn" @click="handleProfileUpdate">저장</button>
-        </template>
+  <div class="profile-page">
+    <!-- Header -->
+    <div class="header-wrapper">
+      <div class="header-content">
+        <button class="back-btn" @click="goBack">
+          <span class="back-icon">←</span>
+        </button>
+        <h1 class="page-title">프로필</h1>
+        <div class="header-actions">
+          <template v-if="!isEditMode">
+            <button class="icon-btn edit-btn" @click="startEdit">
+              <span>✏️</span>
+            </button>
+          </template>
+          <template v-else>
+            <button class="action-btn cancel-btn" @click="cancelEdit">취소</button>
+            <button class="action-btn save-btn" @click="handleProfileUpdate">저장</button>
+          </template>
+        </div>
       </div>
     </div>
 
-    <div v-if="isLoading" class="loading-state">로딩 중...</div>
-    <div v-else-if="error" class="error-state">{{ error }}</div>
+    <!-- Loading State -->
+    <div v-if="isLoading" class="loading-state">
+      <div class="spinner"></div>
+      <p>로딩 중...</p>
+    </div>
+
+    <!-- Error State -->
+    <div v-else-if="error" class="error-state">
+      <span class="error-icon">⚠️</span>
+      <p>{{ error }}</p>
+    </div>
+
+    <!-- Profile Content -->
     <div v-else class="profile-content">
-      <div class="profile-avatar-large">
-        👤
-      </div>
-
-      <div class="info-group">
-        <label>이름</label>
-        <div class="info-value">
-          {{ user.name || '정보 없음' }}
-        </div>
-      </div>
-
-      <div class="info-group">
-        <label>이메일</label>
-        <div class="info-value">
-          {{ user.email || '정보 없음' }}
-        </div>
-        <p class="info-help">이메일은 변경할 수 없습니다</p>
-      </div>
-
-      <div class="info-group">
-        <label for="nickname-input">닉네임</label>
-        <div v-if="!isEditMode" class="info-value">
-          {{ user.nickname || '정보 없음' }}
-        </div>
-        <template v-else>
-          <input id="nickname-input" v-model="editableUser.nickname" type="text" class="info-input" />
-          <p v-if="validationErrors.nickname" class="error-text">{{ validationErrors.nickname }}</p>
-          <!-- Update Message -->
-          <div v-if="updateMessage && isEditMode" class="update-message" :class="updateMessageType">
-            {{ updateMessage }}
+      <!-- Avatar Section -->
+      <div class="avatar-section">
+        <div class="avatar-container">
+          <div class="avatar-circle">
+            <span class="avatar-emoji">👤</span>
           </div>
-        </template>
-      </div>
-
-      <div class="info-group">
-        <label for="phone-input">전화번호</label>
-        <div v-if="!isEditMode" class="info-value">
-          {{ user.phone || '정보 없음' }}
+          <div class="avatar-badge" :class="{ 'edit-mode': isEditMode }">
+            {{ isEditMode ? '수정 중' : '활성' }}
+          </div>
         </div>
-        <template v-else>
-          <input id="phone-input" v-model="editableUser.phone" type="tel" class="info-input" placeholder="010-1234-5678" maxlength="13"/>
-          <p v-if="validationErrors.phone" class="error-text">{{ validationErrors.phone }}</p>
-        </template>
-      </div>
-
-      <div class="info-group">
-        <label>성별</label>
-        <div class="info-value">
-          {{ getGenderText(user.gender) || '정보 없음' }}
+        <div class="user-name-display">
+          <h2>{{ user.name || '사용자' }}</h2>
+          <p class="user-nickname">@{{ user.nickname || 'nickname' }}</p>
         </div>
       </div>
 
-      <div class="info-group">
-        <label>역할</label>
-        <div class="info-value">
-          {{ getRoleText(user.role) }}
+      <!-- Update Message -->
+      <transition name="fade">
+        <div v-if="updateMessage" class="update-message-card" :class="updateMessageType">
+          <span class="message-icon">{{ updateMessageType === 'success' ? '✓' : '✕' }}</span>
+          <span>{{ updateMessage }}</span>
+        </div>
+      </transition>
+
+      <!-- Info Cards -->
+      <div class="info-cards">
+        <!-- Name Card -->
+        <div class="info-card">
+          <div class="card-icon">👤</div>
+          <div class="card-content">
+            <label class="card-label">이름</label>
+            <div class="card-value">{{ user.name || '정보 없음' }}</div>
+          </div>
+        </div>
+
+        <!-- Email Card -->
+        <div class="info-card">
+          <div class="card-icon">📧</div>
+          <div class="card-content">
+            <label class="card-label">이메일</label>
+            <div class="card-value">{{ user.email || '정보 없음' }}</div>
+            <p class="card-hint">변경할 수 없습니다</p>
+          </div>
+        </div>
+
+        <!-- Nickname Card -->
+        <div class="info-card" :class="{ 'editing': isEditMode }">
+          <div class="card-icon">🏷️</div>
+          <div class="card-content">
+            <label for="nickname-input" class="card-label">닉네임</label>
+            <div v-if="!isEditMode" class="card-value">{{ user.nickname || '정보 없음' }}</div>
+            <template v-else>
+              <input
+                id="nickname-input"
+                v-model="editableUser.nickname"
+                type="text"
+                class="card-input"
+                placeholder="닉네임을 입력하세요"
+              />
+              <p v-if="validationErrors.nickname" class="error-text">{{ validationErrors.nickname }}</p>
+            </template>
+          </div>
+        </div>
+
+        <!-- Phone Card -->
+        <div class="info-card" :class="{ 'editing': isEditMode }">
+          <div class="card-icon">📱</div>
+          <div class="card-content">
+            <label for="phone-input" class="card-label">전화번호</label>
+            <div v-if="!isEditMode" class="card-value">{{ user.phone || '정보 없음' }}</div>
+            <template v-else>
+              <input
+                id="phone-input"
+                v-model="editableUser.phone"
+                type="tel"
+                class="card-input"
+                placeholder="010-1234-5678"
+                maxlength="13"
+              />
+              <p v-if="validationErrors.phone" class="error-text">{{ validationErrors.phone }}</p>
+            </template>
+          </div>
+        </div>
+
+        <!-- Gender Card -->
+        <div class="info-card" :class="{ 'editing': isEditMode }">
+          <div class="card-icon">{{ user.gender === 'MALE' ? '♂️' : user.gender === 'FEMALE' ? '♀️' : '⚧' }}</div>
+          <div class="card-content">
+            <label for="gender-select" class="card-label">성별</label>
+            <div v-if="!isEditMode" class="card-value">{{ getGenderText(user.gender) || '정보 없음' }}</div>
+            <template v-else>
+              <select id="gender-select" v-model="editableUser.gender" class="card-select">
+                <option value="MALE">남성</option>
+                <option value="FEMALE">여성</option>
+              </select>
+            </template>
+          </div>
         </div>
       </div>
 
-      <div v-if="!isEditMode" class="delete-account-row">
-        <span class="delete-account" @click="router.push('/delete-account')">회원 탈퇴</span>
+      <!-- Delete Account Section -->
+      <div v-if="!isEditMode" class="danger-zone">
+        <button class="delete-account-btn" @click="router.push('/delete-account')">
+          <span class="delete-icon">🗑️</span>
+          <span>회원 탈퇴</span>
+        </button>
       </div>
     </div>
   </div>
 </template>
 
 <style scoped>
-.profile-page {
-  max-width: 600px;
-  margin: 2rem auto;
-  background: white;
-  padding: 2rem;
-  border-radius: 16px;
-  box-shadow: 0 4px 20px rgba(0,0,0,0.05);
+/* Reset & Base Styles */
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
-.sub-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 2rem;
-  padding-bottom: 0.5rem;
+.profile-page {
+  min-height: 100vh;
+  background: #ffffff;
+  padding-bottom: 2rem;
+}
+
+/* Header */
+.header-wrapper {
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  position: sticky;
+  top: 0;
+  z-index: 100;
   border-bottom: 1px solid #f0f0f0;
 }
 
-.sub-header h3 {
-  flex-grow: 1;
-  text-align: center;
-  font-size: 1.25rem;
+.header-content {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.page-title {
+  font-size: 1.5rem;
   font-weight: 700;
-  margin: 0;
+  color: #333;
+  flex: 1;
+  text-align: center;
 }
 
 .back-btn {
   background: none;
-  font-size: 2rem;
-  padding: 0 0.5rem;
-  line-height: 1;
-  color: #333;
+  border: none;
   cursor: pointer;
+  padding: 0.5rem;
+  transition: transform 0.2s;
 }
 
-.header-buttons {
+.back-btn:hover {
+  transform: translateX(-4px);
+}
+
+.back-icon {
+  font-size: 1.5rem;
+  color: #666;
+}
+
+.header-actions {
   display: flex;
   gap: 0.5rem;
+  align-items: center;
 }
 
-.edit-btn, .save-btn, .cancel-btn {
-  background-color: var(--primary);
-  border-radius: 8px;
+.icon-btn {
+  background: #BFE7DF;
+  border: none;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.9rem;
-  color: #004d40;
-  cursor: pointer;
-  font-weight: 600;
-  padding: 0.5rem 1rem;
+  transition: all 0.3s;
 }
 
-.edit-btn {
-  width: 36px;
-  height: 36px;
+.icon-btn:hover {
+  background: #a8d6cc;
+  transform: translateY(-2px);
+}
+
+.icon-btn span {
   font-size: 1.2rem;
-  padding: 0;
+}
+
+.action-btn {
+  padding: 0.6rem 1.2rem;
+  border: none;
+  border-radius: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s;
+  font-size: 0.9rem;
+}
+
+.save-btn {
+  background: #BFE7DF;
+  color: #333;
+}
+
+.save-btn:hover {
+  background: #a8d6cc;
+  transform: translateY(-2px);
 }
 
 .cancel-btn {
-  background-color: #f0f0f0;
-  color: #555;
+  background: #f5f5f5;
+  color: #666;
 }
 
-
-.loading-state,
-.error-state {
-  text-align: center;
-  padding: 2rem;
-  color: #6b7280;
+.cancel-btn:hover {
+  background: #e8e8e8;
 }
 
-.error-state {
-  color: #ef4444;
-}
-
-.profile-avatar-large {
-  width: 100px;
-  height: 100px;
-  background: #f3f4f6;
-  border-radius: 50%;
-  margin: 0 auto 2.5rem;
+/* Loading & Error States */
+.loading-state {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: 3rem;
+  padding: 4rem 2rem;
+  color: #666;
 }
 
-.info-group {
-  margin-bottom: 2rem;
-}
-
-.info-group label {
-  display: block;
-  font-size: 0.9rem;
-  color: #888;
-  margin-bottom: 0.5rem;
-}
-
-.info-value {
-  font-size: 1.1rem;
-  color: #333;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.info-input {
-  width: 100%;
-  padding: 0.75rem;
-  font-size: 1.1rem;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  box-sizing: border-box;
-}
-
-.info-input:focus {
-  outline: none;
-  border-color: var(--primary);
-  box-shadow: 0 0 0 2px rgba(0, 77, 64, 0.2);
-}
-
-.error-text {
-  color: #ef4444;
-  font-size: 0.8rem;
-  margin-top: 0.5rem;
-}
-
-.info-help {
-  font-size: 0.8rem;
-  color: #aaa;
-  margin-top: 0.25rem;
-  margin-left: 0;
-}
-
-.delete-account-row {
-  margin-top: 3rem;
-  border-top: 1px solid #eee;
-  padding-top: 1.5rem;
-  text-align: center;
-}
-
-.delete-account {
-  color: #004d40;
-  background: var(--primary);
-  padding: 0.5rem 1.5rem;
-  border-radius: 8px;
-  font-size: 0.95rem;
-  cursor: pointer;
-  font-weight: 600;
-}
-
-.update-message {
-  padding: 1rem;
-  border-radius: 8px;
-  font-size: 0.95rem;
-  font-weight: 600;
-  text-align: center;
-  margin-top: 1rem;
+.spinner {
+  width: 50px;
+  height: 50px;
+  border: 4px solid #f0f0f0;
+  border-top-color: #BFE7DF;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
   margin-bottom: 1rem;
 }
 
-.update-message.success {
-  background-color: #d1fae5;
-  color: #065f46;
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 
-.update-message.error {
-  background-color: #fee2e2;
-  color: #dc2626;
+.loading-state p {
+  font-size: 1.1rem;
+  font-weight: 500;
+}
+
+.error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4rem 2rem;
+  color: #666;
+}
+
+.error-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.error-state p {
+  font-size: 1.1rem;
+}
+
+/* Profile Content */
+.profile-content {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+}
+
+/* Avatar Section */
+.avatar-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.avatar-container {
+  position: relative;
+  margin-bottom: 1rem;
+}
+
+.avatar-circle {
+  width: 120px;
+  height: 120px;
+  background: #BFE7DF;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border: 3px solid #ffffff;
+}
+
+.avatar-emoji {
+  font-size: 3.5rem;
+}
+
+.avatar-badge {
+  position: absolute;
+  bottom: 0;
+  right: -5px;
+  background: #A4DD6E;
+  color: #333;
+  padding: 0.3rem 0.8rem;
+  border-radius: 20px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s;
+}
+
+.avatar-badge.edit-mode {
+  background: #FFB84D;
+  color: #333;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.05); }
+}
+
+.user-name-display {
+  text-align: center;
+  color: #333;
+}
+
+.user-name-display h2 {
+  font-size: 1.8rem;
+  font-weight: 700;
+  margin-bottom: 0.3rem;
+}
+
+.user-nickname {
+  font-size: 1rem;
+  color: #666;
+  font-weight: 500;
+}
+
+/* Update Message Card */
+.update-message-card {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 1rem 1.5rem;
+  border-radius: 12px;
+  margin-bottom: 1.5rem;
+  font-weight: 600;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  animation: slideDown 0.3s ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.update-message-card.success {
+  background: #BFE7DF;
+  color: #333;
+  border: 1px solid #a8d6cc;
+}
+
+.update-message-card.error {
+  background: #ffe5e5;
+  color: #d32f2f;
+  border: 1px solid #ffcccc;
+}
+
+.message-icon {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+/* Fade Transition */
+.fade-enter-active, .fade-leave-active {
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+  transform: translateY(-10px);
+}
+
+/* Info Cards */
+.info-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.info-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  display: flex;
+  gap: 1rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  border: 1px solid #f0f0f0;
+  transition: all 0.3s;
+}
+
+.info-card:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-color: #BFE7DF;
+}
+
+.info-card.editing {
+  border: 2px solid #BFE7DF;
+  box-shadow: 0 2px 8px rgba(191, 231, 223, 0.3);
+}
+
+.card-icon {
+  font-size: 2rem;
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f8f8f8;
+  border-radius: 12px;
+  flex-shrink: 0;
+}
+
+.card-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.card-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.card-hint {
+  font-size: 0.8rem;
+  color: #999;
+  font-style: italic;
+}
+
+.card-input,
+.card-select {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  font-size: 1rem;
+  border: 2px solid #e8e8e8;
+  border-radius: 10px;
+  background: #fafafa;
+  transition: all 0.3s;
+  font-weight: 500;
+  color: #333;
+}
+
+.card-input:focus,
+.card-select:focus {
+  outline: none;
+  border-color: #BFE7DF;
+  background: #ffffff;
+  box-shadow: 0 0 0 3px rgba(191, 231, 223, 0.2);
+}
+
+.card-select {
+  cursor: pointer;
+}
+
+.error-text {
+  color: #d32f2f;
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.error-text::before {
+  content: '⚠️';
+}
+
+/* Danger Zone */
+.danger-zone {
+  margin-top: 2rem;
+  padding-top: 2rem;
+  border-top: 1px solid #f0f0f0;
+  text-align: center;
+}
+
+.delete-account-btn {
+  background: #ffffff;
+  color: #d32f2f;
+  border: 2px solid #ffcccc;
+  padding: 1rem 2rem;
+  border-radius: 12px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: all 0.3s;
+}
+
+.delete-account-btn:hover {
+  background: #ffe5e5;
+  border-color: #d32f2f;
+  transform: translateY(-2px);
+}
+
+.delete-icon {
+  font-size: 1.2rem;
+}
+
+/* Responsive Design */
+@media (max-width: 640px) {
+  .profile-content {
+    padding: 1.5rem 1rem;
+  }
+
+  .header-content {
+    padding: 1rem;
+  }
+
+  .page-title {
+    font-size: 1.3rem;
+  }
+
+  .avatar-circle {
+    width: 100px;
+    height: 100px;
+  }
+
+  .avatar-emoji {
+    font-size: 3rem;
+  }
+
+  .user-name-display h2 {
+    font-size: 1.5rem;
+  }
+
+  .info-card {
+    padding: 1.2rem;
+  }
+
+  .card-icon {
+    font-size: 1.8rem;
+    width: 45px;
+    height: 45px;
+  }
 }
 </style>


### PR DESCRIPTION
 ## 💡 PR 제목
  feat: [LJH] 회원 탈퇴 로직 개선 및 마이프로필 UI 개선

  ---

  ## 🔗 관련 이슈
  - Refs: #198 

  ---

  ## 📌 작업 내용 요약
  - [x] 회원 탈퇴 시 외래키 제약조건 위반 오류 해결
  - [x] 환불 기록 삭제 로직 개선 (조회 후 일괄 삭제)
  - [x] 마이프로필 페이지 UI/UX 개선
  - [x] 회원 탈퇴 페이지 에러 핸들링 강화

  ---

  ## 🧱 변경 범위 (Scope)
  ### Backend
  - [x] API 추가/수정
  - [x] Validation/예외처리
  - [ ] 인증/인가
  - [x] DB 스키마/쿼리
  - [ ] 기타:

  ### Frontend
  - [x] UI/라우팅
  - [x] 상태관리/비동기 로직
  - [x] 입력값/검증
  - [ ] 기타:

  ---

  ## 🧪 테스트 내역
  ### Backend
  - [x] 로컬에서 애플리케이션 실행 확인
  - [ ] 단위 테스트 통과
  - [x] API 수동 테스트 (Postman / Swagger 등)

  ### Frontend
  - [x] `npm run dev` 로컬 실행 확인
  - [x] 주요 화면/기능 수동 테스트

  ### 테스트 상세(필수)
  #### Backend
  - 회원 탈퇴 API 테스트 (환불 기록이 있는 사용자)
  - 회원 탈퇴 API 테스트 (진행 중인 예약이 있는 경우 - 실패 케이스)
  - 회원 탈퇴 API 테스트 (정상 탈퇴 케이스)
  - 외래키 제약조건 위반 오류 해결 확인

  #### Frontend
  - 프로필 페이지 조회/수정 기능
  - 닉네임, 전화번호 유효성 검증
  - 회원 탈퇴 프로세스 (2단계)
  - 성공/실패 시 모달 표시 확인

  ---

  ## 🖼️ 화면 캡처 / 시연 영상 (Frontend 변경 시 권장)
  - before: 기존 프로필 페이지 및 회원 탈퇴 페이지
  - after: 개선된 UI/UX (카드형 레이아웃, 편집 모드, 성공/에러 메시지 표시)

  ---

  ## ⚠️ 영향도 / 리스크 / 롤백
  ### 영향도
  - Backend: 회원 탈퇴 API의 데이터 삭제 순서가 변경됨 (환불 → 결제 → 예약 → 기타)
  - Frontend: 기존 API 응답 형식에는 변경 없음, UI만 개선됨

  ### 리스크
  - 낮음 : 데이터 삭제 순서만 변경되었으며, 외래키 제약조건을 준수하도록 개선됨
  - 트랜잭션 내에서 처리되므로 부분 삭제 위험 없음
  - 환불 기록이 많은 경우 조회 성능 이슈 가능성 (현재 규모에서는 문제 없음)

  ### 롤백 방법
  - Revert 커밋으로 즉시 롤백 가능
  - DB 마이그레이션 없음 (스키마 변경 없음)

  ---

  ## ✅ 리뷰어 체크 포인트 (선택)
   Backend
  - 트랜잭션 범위: `@Transactional` 어노테이션이 적용되어 있어 부분 삭제 없이 롤백됨
  - 삭제 순서: 환불(자식) → 결제(부모) → 예약 → 리뷰 신고 → 리뷰 → 위시리스트 → 소셜 로그인 → 사용자 순서로 삭제
  - 성능: `flatMap`으로 환불 기록을 조회하는 부분 - 환불 기록이 많지 않은 서비스 특성상 문제 없음
  - 로깅: 각 단계별로 삭제된 레코드 수를 로그에 기록하여 디버깅 용이

   Frontend
  - **유효성 검증**: 닉네임 (2-10자), 전화번호 (010-xxxx-xxxx) 형식 검증
  - **에러 핸들링**: API 응답 코드별 상세한 에러 메시지 표시
  - **사용자 경험**: 편집 모드 진입/취소 시 상태 초기화, 성공 메시지 2초 후 자동 닫힘

  ---
  주요 변경 사항 설명:

  Backend (UserServiceImpl.java:67-87)

  // 기존: deleteByPaymentIdIn() 사용 → 제대로 작동하지 않음
  paymentRefundJpaRepository.deleteByPaymentIdIn(paymentIds);

  // 개선: 환불 기록을 먼저 조회한 후 일괄 삭제
  List<PaymentRefund> refunds = paymentIds.stream()
      .flatMap(paymentId -> paymentRefundJpaRepository.findByPaymentId(paymentId).stream())
      .collect(Collectors.toList());

  if (!refunds.isEmpty()) {
      paymentRefundJpaRepository.deleteAllInBatch(refunds);
      log.info("사용자 {}의 환불 기록 {}건 삭제 완료", email, refunds.size());
  }

  해결한 문제:
  - DataIntegrityViolationException: Cannot delete or update a parent row: a foreign key constraint fails 오류 해결
  - 환불 기록(자식)을 먼저 삭제한 후 결제 기록(부모)을 삭제하도록 순서 보장
