### PR TITLE
feat: 테마 UI 개선 및 카테고리 분류 적용

### DIFF
--- a/backend/src/main/resources/db/migration/V9__replace_theme_data.sql
+++ b/backend/src/main/resources/db/migration/V9__replace_theme_data.sql
@@ -26,7 +26,7 @@ INSERT INTO theme (theme_category, theme_name, theme_image_url) VALUES
 ('CULTURE', '문화유적', 'https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Classical%20building/3D/classical_building_3d.png'),
 
 -- 3. ACTIVITY (액티비티)
-('ACTIVITY', '서핑', 'https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Person%20surfing/3D/person_surfing_3d.png'),
+('ACTIVITY', '서핑', 'https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Person%20surfing%3A%20light%20skin%20tone/3D/person_surfing_light_skin_tone_3d.png'),
 ('ACTIVITY', '수상레저', 'https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Speedboat/3D/speedboat_3d.png'),
 ('ACTIVITY', '워터파크', 'https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Playground%20slide/3D/playground_slide_3d.png'),
 ('ACTIVITY', '러닝', 'https://raw.githubusercontent.com/microsoft/fluentui-emoji/main/assets/Person%20running/3D/person_running_3d.png'),

--- a/frontend/src/views/SocialSignupView/SocialSignupView.vue
+++ b/frontend/src/views/SocialSignupView/SocialSignupView.vue
@@ -144,6 +144,32 @@ const themes = ref([])
 const themesLoading = ref(false)
 const themesError = ref('')
 
+// 카테고리별 이모지와 한글 이름 매핑
+const categoryInfo = {
+  'NATURE': { emoji: '🌿', name: '자연' },
+  'CULTURE': { emoji: '🏛️', name: '문화' },
+  'ACTIVITY': { emoji: '🏄', name: '활동' },
+  'VIBE': { emoji: '✨', name: '분위기' },
+  'PARTY': { emoji: '🥳', name: '파티' },
+  'MEETING': { emoji: '💞', name: '만남' },
+  'PERSONA': { emoji: '👤', name: '특성/성향' },
+  'FACILITY': { emoji: '🏠', name: '시설' },
+  'FOOD': { emoji: '🍴', name: '음식' },
+  'PLAY': { emoji: '🎮', name: '놀이' }
+}
+
+// 카테고리별로 그룹화된 테마
+const groupedThemes = computed(() => {
+  const groups = {}
+  themes.value.forEach(theme => {
+    if (!groups[theme.category]) {
+      groups[theme.category] = []
+    }
+    groups[theme.category].push(theme)
+  })
+  return groups
+})
+
 const loadThemes = async () => {
   themesLoading.value = true
   themesError.value = ''
@@ -153,6 +179,7 @@ const loadThemes = async () => {
       // 백엔드에서 받은 테마를 프론트엔드 형식으로 변환
       themes.value = response.data.map(theme => ({
         id: theme.id,
+        category: theme.themeCategory,
         label: theme.themeName,
         imageUrl: theme.themeImageUrl,
         selected: false
@@ -170,7 +197,20 @@ const loadThemes = async () => {
 }
 
 const toggleTheme = (theme) => {
-  theme.selected = !theme.selected
+  // 이미 선택된 테마를 해제하는 경우
+  if (theme.selected) {
+    theme.selected = false
+    return
+  }
+
+  // 새로 선택하는 경우 - 최대 3개 제한
+  const selectedCount = themes.value.filter(t => t.selected).length
+  if (selectedCount >= 3) {
+    openModal('테마는 최대 3개까지만 선택할 수 있습니다.', 'info')
+    return
+  }
+
+  theme.selected = true
 }
 
 // Modal
@@ -346,33 +386,40 @@ const handleSkip = async () => {
       <template v-if="currentStep === 2">
         <div class="theme-section">
           <h2 class="theme-title">관심 테마를 선택해주세요</h2>
-          <p class="theme-desc">마음에 드는 여행 스타일을 선택하시면<br/>꼭 맞는 숙소를 추천해 드립니다. (여러 개 선택 가능)</p>
+          <p class="theme-desc">마음에 드는 여행 스타일을 선택하시면<br/>꼭 맞는 숙소를 추천해 드립니다. (최대 3개 선택 가능)</p>
 
           <div v-if="themesLoading" class="theme-loading">
             <div class="spinner"></div>
             <p>테마 목록을 불러오는 중...</p>
           </div>
           <div v-else-if="themesError" class="theme-error">{{ themesError }}</div>
-          <div v-else class="theme-grid">
-            <button
-              type="button"
-              v-for="theme in themes"
-              :key="theme.id"
-              class="theme-card"
-              :class="{ selected: theme.selected }"
-              @click="toggleTheme(theme)"
+          <div v-else class="theme-categories">
+            <div
+              v-for="(categoryThemes, categoryKey) in groupedThemes"
+              :key="categoryKey"
+              class="category-section"
             >
-              <img :src="theme.imageUrl" :alt="theme.label" class="theme-image" />
-              <div class="theme-overlay"></div>
-              <div class="theme-label-container">
-                <span class="theme-label">{{ theme.label }}</span>
+              <h3 class="category-header">
+                <span class="category-emoji">{{ categoryInfo[categoryKey]?.emoji }}</span>
+                <span class="category-name">{{ categoryInfo[categoryKey]?.name }}</span>
+              </h3>
+              <div class="theme-chips">
+                <button
+                  type="button"
+                  v-for="theme in categoryThemes"
+                  :key="theme.id"
+                  class="theme-chip"
+                  :class="{ selected: theme.selected }"
+                  @click="toggleTheme(theme)"
+                >
+                  <img :src="theme.imageUrl" :alt="theme.label" class="chip-icon" />
+                  <span class="chip-label">{{ theme.label }}</span>
+                  <div class="chip-check" v-if="theme.selected">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+                  </div>
+                </button>
               </div>
-              <div class="theme-checkbox-wrapper">
-                <div class="theme-checkbox">
-                  <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
-                </div>
-              </div>
-            </button>
+            </div>
           </div>
         </div>
 
@@ -390,6 +437,9 @@ const handleSkip = async () => {
     <!-- Modal -->
     <div v-if="showModal" class="modal-overlay" @click.self="closeModal">
       <div class="modal-content">
+        <button class="modal-close-btn" @click="closeModal">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+        </button>
         <div class="modal-icon" :class="modalType">
           <span v-if="modalType === 'success'">✓</span>
           <span v-else-if="modalType === 'error'">!</span>
@@ -403,6 +453,9 @@ const handleSkip = async () => {
     <!-- Terms Modal -->
     <div v-if="showTermsModal" class="modal-overlay" @click.self="closeTermsModal">
       <div class="modal-content large">
+        <button class="modal-close-btn" @click="closeTermsModal">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+        </button>
         <h2>{{ termsModalTitle }}</h2>
         <div class="terms-content-scroll">
           <div v-html="termsModalContent"></div>
@@ -669,118 +722,103 @@ const handleSkip = async () => {
   background-color: #fee2e2;
   border-radius: 8px;
 }
-.theme-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: 1rem;
+
+/* 카테고리별 테마 레이아웃 */
+.theme-categories {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  text-align: left;
 }
-.theme-card {
-  position: relative;
-  border-radius: 16px;
-  overflow: hidden;
-  cursor: pointer;
-  aspect-ratio: 1 / 1;
-  border: 3px solid #e5e7eb;
-  transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+
+.category-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
-.theme-card:hover {
-  transform: translateY(-6px);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.12);
-  border-color: var(--accent-color);
-}
-.theme-card.selected {
-  border-color: #BFE7DF;
-  border-width: 4px;
-  transform: translateY(-6px) scale(1.03);
-  box-shadow: 0 12px 28px rgba(191, 231, 223, 0.5);
-}
-.theme-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.4s ease;
-}
-.theme-card:hover .theme-image {
-  transform: scale(1.1);
-}
-.theme-overlay {
-  position: absolute;
-  top: 0; left: 0; right: 0; bottom: 0;
-  background: rgba(0,0,0,0.1);
-  transition: background-color 0.3s ease;
-}
-.theme-card:hover .theme-overlay {
-  background: rgba(0,0,0,0.25);
-}
-.theme-card.selected .theme-overlay {
-  background: linear-gradient(135deg, rgba(191, 231, 223, 0.4) 0%, rgba(109, 195, 187, 0.5) 100%);
-}
-.theme-label-container {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.3), transparent);
-  padding: 10px 12px;
-  transition: all 0.3s ease;
-}
-.theme-card.selected .theme-label-container {
-  background: linear-gradient(to top, rgba(191, 231, 223, 0.95), rgba(191, 231, 223, 0.85));
-}
-.theme-label {
-  color: white;
+
+.category-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.1rem;
   font-weight: 700;
-  font-size: 0.95rem;
-  text-align: center;
-  display: block;
-  width: 100%;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+  color: var(--text-primary);
+  margin: 0;
 }
-.theme-card.selected .theme-label {
-  color: #004d40;
-  text-shadow: none;
-}
-.theme-checkbox-wrapper {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  width: 28px;
-  height: 28px;
-  background: rgba(255, 255, 255, 0.3);
-  backdrop-filter: blur(8px);
-  border-radius: 50%;
+
+.category-emoji {
+  font-size: 1.4rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.3s ease;
-  transform: scale(0.5);
-  opacity: 0;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
-.theme-checkbox {
-  width: 22px;
-  height: 22px;
-  background: var(--background-white);
-  border-radius: 50%;
+
+.category-name {
+  letter-spacing: -0.02em;
+}
+
+/* 테마 칩 레이아웃 */
+.theme-chips {
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.theme-chip {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  color: var(--primary-dark);
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  background: white;
   border: 2px solid var(--border-color);
-  transition: all 0.3s ease;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border-radius: 24px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+  position: relative;
 }
-.theme-card.selected .theme-checkbox-wrapper {
-  transform: scale(1);
-  opacity: 1;
-  background: rgba(255, 255, 255, 0.5);
+
+.theme-chip:hover {
+  border-color: #BFE7DF;
+  background: #f0fdf9;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(191, 231, 223, 0.2);
 }
-.theme-card.selected .theme-checkbox {
+
+.theme-chip.selected {
+  background: #BFE7DF;
+  border-color: #6DC3BB;
+  color: #004d40;
+  box-shadow: 0 4px 12px rgba(191, 231, 223, 0.4);
+}
+
+.chip-icon {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.chip-label {
+  white-space: nowrap;
+  letter-spacing: -0.02em;
+}
+
+.chip-check {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
   background: #6DC3BB;
+  border-radius: 50%;
   color: white;
-  border-color: white;
-  box-shadow: 0 2px 8px rgba(109, 195, 187, 0.4);
+  margin-left: 0.25rem;
+  flex-shrink: 0;
 }
 
 /* Buttons */
@@ -868,6 +906,29 @@ const handleSkip = async () => {
   text-align: center;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
   animation: slideUp 0.3s ease;
+  position: relative;
+}
+.modal-close-btn {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--text-secondary);
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+}
+.modal-close-btn:hover {
+  background: var(--background-light);
+  color: var(--text-primary);
+  transform: rotate(90deg);
 }
 @keyframes slideUp {
   from { transform: translateY(20px); opacity: 0; }


### PR DESCRIPTION
● ## 💡 PR 제목
  > feat: [LJH] 소셜 회원가입 테마 선택 UI 개선 - 카테고리별 칩 스타일 적용

  ---

  ## 🔗 관련 이슈
  - Refs: #

  ---

  ## 📌 작업 내용 요약
  - [x] 테마 선택 UI를 카테고리별로 그룹화하여 표시
  - [x] 카테고리 헤더에 이모지 + 한글 제목 추가 (영어 제거)
  - [x] 기존 그리드 카드 레이아웃을 가로 방향 칩/배지 스타일로 변경
  - [x] 테마 선택 개수를 최대 3개로 제한
  - [x] 모달창에 우측 상단 닫기(X) 버튼 추가

  ---

  ## 🧱 변경 범위 (Scope)
  ### Backend
  - [ ] API 추가/수정
  - [ ] Validation/예외처리
  - [ ] 인증/인가
  - [ ] DB 스키마/쿼리
  - [ ] 기타:

  ### Frontend
  - [x] UI/라우팅
  - [x] 상태관리/비동기 로직
  - [ ] 입력값/검증
  - [ ] 기타:

  ---

  ## 🧪 테스트 내역
  ### Backend
  - [ ] 로컬에서 애플리케이션 실행 확인
  - [ ] 단위 테스트 통과
  - [ ] API 수동 테스트 (Postman / Swagger 등)

  ### Frontend
  - [x] `npm run dev` 로컬 실행 확인
  - [x] 주요 화면/기능 수동 테스트

  ### 테스트 상세(필수)
  - 소셜 회원가입 Step 2 (테마 선택) 화면 진입
  - 카테고리별 테마 목록 정상 표시 확인 (10개 카테고리: 자연, 문화, 활동, 분위기, 파티, 만남, 특성/성향, 시설, 음식, 놀이)
  - 테마 칩 선택/해제 기능 동작 확인
  - 최대 3개 선택 제한 동작 확인 (4번째 선택 시 모달 표시)
  - 모달창 X 버튼 클릭으로 닫기 동작 확인
  - 약관 모달 X 버튼 클릭으로 닫기 동작 확인
  - 테마 선택 후 회원가입 완료 플로우 정상 동작 확인

  ---

  ## 🖼️ 화면 캡처 / 시연 영상 (Frontend 변경 시 권장)
  - before: 그리드 카드 스타일, 카테고리 구분 없음, 선택 개수 제한 없음
  - after: 카테고리별 그룹화된 칩 스타일, 최대 3개 선택 제한, 모달 X 버튼 추가

  ---

  ## ⚠️ 영향도 / 리스크 / 롤백
  - **영향도**: Frontend UI 변경만 해당, 기존 API 응답 및 데이터 구조 변경 없음
  - **리스크**:
    - 기존에 3개 이상 테마를 선택한 사용자 데이터가 있을 경우 UI에서는 정상 표시되나, 신규 선택 시 3개 제한 적용됨
    - 카테고리 정보가 없는 테마가 있을 경우 그룹화에서 제외될 수 있음 (현재 모든 테마에 category 존재)
  - **롤백 방법**: revert 커밋으로 즉시 롤백 가능, DB 변경 없음

  ---

  ## ✅ 리뷰어 체크 포인트 (선택)
  - `groupedThemes` computed 로직에서 카테고리 그룹화가 올바르게 동작하는지
  - 최대 3개 선택 제한 로직 (`toggleTheme` 함수)
  - 모달 X 버튼의 접근성 및 사용성
  - 칩 스타일의 반응형 동작 (flex-wrap)
