### PR TITLE
feat : 소셜 수정

### DIFF
--- a/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/service/OAuth2AuthenticationSuccessHandler.java
+++ b/backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/service/OAuth2AuthenticationSuccessHandler.java
@@ -22,11 +22,11 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    // 상대 경로 사용 (프론트/백엔드 같은 도메인)
-    private String redirectUri = "/oauth2/redirect";
+    @Value("${oauth2.redirect-uri}")
+    private String redirectUri;
 
-    // 상대 경로 사용
-    private String signupRedirectUri = "/social-signup";
+    @Value("${oauth2.signup-redirect-uri}")
+    private String signupRedirectUri;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -107,8 +107,8 @@ ncp.chatbot.invoke-url=${NCLOUD_CHATBOT_INVOKE_URL}
 ncp.chatbot.signature-secret=${NCLOUD_CHATBOT_SIGNATURE_SECRET}
 
 # OAuth2 Redirect URI (for frontend)
-oauth2.redirect-uri=http://localhost:5173/oauth2/redirect
-oauth2.signup-redirect-uri=http://localhost:5173/social-signup
+oauth2.redirect-uri=http://localhost:5174/oauth2/redirect
+oauth2.signup-redirect-uri=http://localhost:5174/social-signup
 
 # Redis Cache  redis ??? simple -> redis ? ??
 spring.data.redis.host=localhost
@@ -119,10 +119,13 @@ spring.cache.redis.time-to-live=600000
 # Flyway Validation 비활성화 (개발 중 체크섬 불일치 해결용)
 spring.flyway.validate-on-migrate=false
 
+# Google OAuth2 Login
+spring.security.oauth2.client.registration.google.client-name=Google
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
+spring.security.oauth2.client.registration.google.authorization-grant-type=authorization_code
+
 # Kakao OAuth2 Login (Provider Settings)
-# TODO: Kakao Developers에서 client-id/secret 발급 후 주석 해제
-spring.security.oauth2.client.registration.kakao.client-id=YOUR_KAKAO_CLIENT_ID
-spring.security.oauth2.client.registration.kakao.client-secret=YOUR_KAKAO_CLIENT_SECRET
+# client-id와 client-secret은 application-secret.properties에 정의됨
 spring.security.oauth2.client.registration.kakao.client-name=Kakao
 spring.security.oauth2.client.registration.kakao.redirect-uri=http://localhost:8080/login/oauth2/code/kakao
 spring.security.oauth2.client.registration.kakao.authorization-grant-type=authorization_code

--- a/frontend/src/views/LoginView/LoginView.vue
+++ b/frontend/src/views/LoginView/LoginView.vue
@@ -97,7 +97,7 @@ const handleLogin = async () => {
 
 const socialLogin = (provider) => {
   // 백엔드 OAuth2 URL로 리다이렉트
-  const baseUrl = window.location.origin
+  const baseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
   const redirect = typeof route.query.redirect === 'string' ? route.query.redirect : ''
   if (redirect.startsWith('/')) {
     sessionStorage.setItem('postLoginRedirect', redirect)
@@ -105,9 +105,9 @@ const socialLogin = (provider) => {
     sessionStorage.removeItem('postLoginRedirect')
   }
   const urls = {
-    Google: `${baseUrl}/oauth2/authorization/google`, // Google OAuth2 (구현 필요)
-    Kakao: `${baseUrl}/oauth2/authorization/kakao`, // Kakao OAuth2 (구현 필요)
-    Naver: `${baseUrl}/oauth2/authorization/naver` // Naver OAuth2 (구현 완료)
+    Google: `${baseUrl}/oauth2/authorization/google`,
+    Kakao: `${baseUrl}/oauth2/authorization/kakao`,
+    Naver: `${baseUrl}/oauth2/authorization/naver`
   }
 
   if (provider === 'Naver' || provider === 'Google' || provider === 'Kakao') {


### PR DESCRIPTION
 ## 💡 PR 제목
 > feat: [LJH] 소셜 로그인(네이버/구글/카카오) 오류 수정

 ---

 ## 🔗 관련 이슈
 > 진행 중이면 `Refs #123`, 완전 해결이면 `Closes #123` (완전히 끝났을 때만)
 - Refs/Closes: #256 

 ---

 ## 📌 작업 내용 요약
 - [x] 프론트엔드 OAuth 요청 URL 수정 (프론트엔드 주소 → 백엔드 주소)
 - [x] 백엔드 OAuth 리다이렉트 URL 수정 (상대 경로 → 절대 경로)
 - [x] 구글 OAuth 설정 추가 및 카카오 OAuth placeholder 제거
 - [x] 프론트엔드 포트 불일치 해결 (5173 → 5174)
 - [x] 트러블슈팅 문서 작성

 ---

 ## 🧱 변경 범위 (Scope)
 ### Backend
 - [x] 인증/인가
 - [x] 기타: OAuth2 설정 파일 수정

 ### Frontend
 - [x] UI/라우팅
 - [x] 기타: OAuth 요청 로직 수정

 ---

 ## 🔧 상세 변경 내용

 ### 1. Frontend - OAuth 요청 URL 수정
 **파일**: `frontend/src/views/LoginView/LoginView.vue:100`

 **문제**:
 - `window.location.origin` 사용으로 프론트엔드 주소(localhost:5174)로 OAuth 요청
 - OAuth 엔드포인트는 백엔드(localhost:8080)에 있어야 함

 **수정**:
 ```javascript
 // Before
 const baseUrl = window.location.origin

 // After
 const baseUrl = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080'
 ```

 ### 2. Backend - OAuth 리다이렉트 URL 수정
 **파일**: `backend/src/main/java/com/ssg9th2team/geharbang/global/oauth/service/OAuth2AuthenticationSuccessHandler.java:25-29`

 **문제**:
 - 상대 경로 사용으로 백엔드 서버 기준으로 리다이렉트 (`/oauth2/redirect`)
 - 프론트엔드로 JWT 토큰이 전달되지 않음

 **수정**:
 ```java
 // Before
 private String redirectUri = "/oauth2/redirect";
 private String signupRedirectUri = "/social-signup";

 // After
 @Value("${oauth2.redirect-uri}")
 private String redirectUri;

 @Value("${oauth2.signup-redirect-uri}")
 private String signupRedirectUri;
 ```

 ### 3. Backend - application.properties 수정
 **파일**: `backend/src/main/resources/application.properties`

 **변경 1 - 구글 OAuth 설정 추가 (122-125줄)**:
 ```properties
 # Google OAuth2 Login
 spring.security.oauth2.client.registration.google.client-name=Google
 spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
 spring.security.oauth2.client.registration.google.authorization-grant-type=authorization_code
 ```

 **변경 2 - 카카오 OAuth placeholder 제거 (128줄)**:
 ```properties
 # Before
 spring.security.oauth2.client.registration.kakao.client-id=YOUR_KAKAO_CLIENT_ID
 spring.security.oauth2.client.registration.kakao.client-secret=YOUR_KAKAO_CLIENT_SECRET

 # After (주석 추가)
 # client-id와 client-secret은 application-secret.properties에 정의됨
 ```

 **변경 3 - 프론트엔드 포트 수정 (110-111줄)**:
 ```properties
 # Before
 oauth2.redirect-uri=http://localhost:5173/oauth2/redirect
 oauth2.signup-redirect-uri=http://localhost:5173/social-signup

 # After
 oauth2.redirect-uri=http://localhost:5174/oauth2/redirect
 oauth2.signup-redirect-uri=http://localhost:5174/social-signup
 ```

 ### 4. 문서화
 - 문제 원인 분석
 - OAuth 플로우 비교 (정상 vs 오류)
 - 수정 사항 상세 설명
 - 검증 방법 및 체크리스트

 ---

 ## 🧪 테스트 내역
 ### Backend
 - [x] 로컬에서 애플리케이션 실행 확인
 - [x] API 수동 테스트 (OAuth 플로우 확인)
 - [x] 백엔드 로그 확인 (OAuth 성공 로그)

 ### Frontend
 - [x] `npm run dev` 로컬 실행 확인
 - [x] 주요 화면/기능 수동 테스트

 ### 테스트 상세
 **네이버 소셜 로그인**:
 - ✅ 로그인 버튼 클릭 → `http://localhost:8080/oauth2/authorization/naver`로 정상 이동
 - ✅ 네이버 로그인 화면 표시
 - ✅ 로그인 성공 → `http://localhost:5174/oauth2/redirect?accessToken=...&refreshToken=...`로 리다이렉트
 - ✅ JWT 토큰 sessionStorage 저장 확인
 - ✅ 백엔드 로그: `OAuth2 Login Success - User: 0321ljh@naver.com`

 **구글 소셜 로그인**:
 - 테스트 예정 (설정 완료, 구글 계정으로 테스트 필요)

 **카카오 소셜 로그인**:
 - 테스트 예정 (설정 완료, 카카오 계정으로 테스트 필요)

 ---

 ## 🖼️ 화면 캡처 / 시연 영상
 ### Before:
 - 소셜 로그인 버튼 클릭 시 로그인 화면이 나타나지 않음
 - 로그인 성공 후에도 인증되지 않고 `/login`으로 돌아감
 - 백엔드 로그에는 성공 메시지가 있으나 프론트엔드에 토큰 미전달

 ### After:
 - 소셜 로그인 버튼 클릭 → 각 제공자의 로그인 화면 정상 표시
 - 로그인 성공 → 프론트엔드로 JWT 토큰과 함께 리다이렉트
 - 메인 페이지 또는 이전 페이지로 정상 이동


 ---

 ## ⚠️ 영향도 / 리스크 / 롤백

 ### 영향도
 - **중간**: OAuth 소셜 로그인 전체 플로우에 영향
 - 기존 이메일 로그인에는 영향 없음
 - 기존 소셜 로그인 사용자: 재로그인 시 정상 작동

 ### 리스크
 - **낮음**:
   - OAuth 설정 변경이므로 기존 데이터베이스나 API에 영향 없음
   - 백엔드 재시작 필요
   - 프론트엔드 빌드 재배포 필요

 ### 주의사항
 - OAuth 제공자 콘솔에서 Redirect URI 등록 확인 필요:
   - 네이버: `http://localhost:8080/login/oauth2/code/naver`
   - 구글: `http://localhost:8080/login/oauth2/code/google`
   - 카카오: `http://localhost:8080/login/oauth2/code/kakao`

 ### 롤백 방법
 - **쉬움**: revert 커밋으로 즉시 롤백 가능
 - DB 마이그레이션 없음
 - 외부 의존성 변경 없음

 ---

 ## ✅ 리뷰어 체크 포인트

 ### 필수 확인사항
 1. **OAuth2AuthenticationSuccessHandler.java**:
    - `@Value` 주입이 정상적으로 작동하는지 확인
    - 절대 URL로 리다이렉트되는지 확인

 2. **application.properties**:
    - 구글 OAuth 설정이 올바른지 확인
    - 프론트엔드 포트(5174)가 실제 환경과 일치하는지 확인

 3. **LoginView.vue**:
    - `VITE_API_BASE_URL` 환경 변수가 제대로 설정되어 있는지 확인
    - OAuth 요청이 백엔드로 가는지 확인

 ### 권장 확인사항
 - 백엔드 로그에서 OAuth 성공 메시지 확인
 - 브라우저 Network 탭에서 리다이렉트 플로우 확인
 - JWT 토큰이 sessionStorage에 저장되는지 확인

 ### 프로덕션 배포 전 필수 작업
 - [ ] 프로덕션 도메인에 맞춰 `oauth2.redirect-uri` 수정
 - [ ] 각 OAuth 제공자 콘솔에서 프로덕션 Redirect URI 추가
 - [ ] HTTPS 적용 확인

 ---

 ## 📚 참고 문서
 - `OAUTH_TROUBLESHOOTING.md`: 상세 트러블슈팅 가이드
 - Spring Security OAuth2 공식 문서
 - 네이버/구글/카카오 OAuth 개발 가이드
